### PR TITLE
fix: fetch response fields not nullable and miss payload empty

### DIFF
--- a/src/Momento.Sdk.Incubating/Responses/CacheDictionaryFetchResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheDictionaryFetchResponse.cs
@@ -49,31 +49,7 @@ public abstract class CacheDictionaryFetchResponse
 
     public class Miss : CacheDictionaryFetchResponse
     {
-        protected readonly Lazy<Dictionary<byte[], byte[]>?> _byteArrayByteArrayDictionary;
-        protected readonly Lazy<Dictionary<string, string>?> _stringStringDictionary;
-        protected readonly Lazy<Dictionary<string, byte[]>?> _stringByteArrayDictionary;
-        public Miss()
-        {
-            _byteArrayByteArrayDictionary = new(() =>
-            {
-                return null;
-            });
 
-            _stringStringDictionary = new(() =>
-            {
-                return null;
-            });
-            _stringByteArrayDictionary = new(() =>
-            {
-                return null;
-            });
-        }
-
-        public Dictionary<byte[], byte[]>? ByteArrayByteArrayDictionary { get => _byteArrayByteArrayDictionary.Value; }
-
-        public Dictionary<string, string>? StringStringDictionary() => _stringStringDictionary.Value;
-
-        public Dictionary<string, byte[]>? StringByteArrayDictionary() => _stringByteArrayDictionary.Value;
     }
 
     public class Error : CacheDictionaryFetchResponse

--- a/src/Momento.Sdk.Incubating/Responses/CacheDictionaryFetchResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheDictionaryFetchResponse.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using Google.Protobuf.Collections;
 using Momento.Protos.CacheClient;
+using Momento.Sdk.Exceptions;
 using Momento.Sdk.Internal;
 using Momento.Sdk.Responses;
-using Momento.Sdk.Exceptions;
 
 namespace Momento.Sdk.Incubating.Responses;
 
@@ -14,9 +14,9 @@ public abstract class CacheDictionaryFetchResponse
     public class Hit : CacheDictionaryFetchResponse
     {
         protected readonly RepeatedField<_DictionaryFieldValuePair>? items;
-        protected readonly Lazy<Dictionary<byte[], byte[]>?> _byteArrayByteArrayDictionary;
-        protected readonly Lazy<Dictionary<string, string>?> _stringStringDictionary;
-        protected readonly Lazy<Dictionary<string, byte[]>?> _stringByteArrayDictionary;
+        protected readonly Lazy<Dictionary<byte[], byte[]>> _byteArrayByteArrayDictionary;
+        protected readonly Lazy<Dictionary<string, string>> _stringStringDictionary;
+        protected readonly Lazy<Dictionary<string, byte[]>> _stringByteArrayDictionary;
 
         public Hit(_DictionaryFetchResponse response)
         {
@@ -40,11 +40,11 @@ public abstract class CacheDictionaryFetchResponse
             });
         }
 
-        public Dictionary<byte[], byte[]>? ByteArrayByteArrayDictionary { get => _byteArrayByteArrayDictionary.Value; }
+        public Dictionary<byte[], byte[]> ByteArrayByteArrayDictionary { get => _byteArrayByteArrayDictionary.Value; }
 
-        public Dictionary<string, string>? StringStringDictionary() => _stringStringDictionary.Value;
+        public Dictionary<string, string> StringStringDictionary() => _stringStringDictionary.Value;
 
-        public Dictionary<string, byte[]>? StringByteArrayDictionary() => _stringByteArrayDictionary.Value;
+        public Dictionary<string, byte[]> StringByteArrayDictionary() => _stringByteArrayDictionary.Value;
     }
 
     public class Miss : CacheDictionaryFetchResponse

--- a/src/Momento.Sdk.Incubating/Responses/CacheDictionaryGetResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheDictionaryGetResponse.cs
@@ -32,16 +32,7 @@ public abstract class CacheDictionaryGetResponse
 
     public class Miss : CacheDictionaryGetResponse
     {
-        public Miss() { }
-        public byte[]? ByteArray
-        {
-            get
-            {
-                return null;
-            }
-        }
 
-        public string? String() => null;
     }
 
     public class Error : CacheDictionaryGetResponse

--- a/src/Momento.Sdk.Incubating/Responses/CacheListFetchResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheListFetchResponse.cs
@@ -13,9 +13,9 @@ public abstract class CacheListFetchResponse
 {
     public class Hit : CacheListFetchResponse
     {
-        protected readonly RepeatedField<ByteString>? values;
-        protected readonly Lazy<List<byte[]>?> _byteArrayList;
-        protected readonly Lazy<List<string>?> _stringList;
+        protected readonly RepeatedField<ByteString> values;
+        protected readonly Lazy<List<byte[]>> _byteArrayList;
+        protected readonly Lazy<List<string>> _stringList;
 
         public Hit(_ListFetchResponse response)
         {
@@ -31,9 +31,9 @@ public abstract class CacheListFetchResponse
             });
         }
 
-        public List<byte[]>? ByteArrayList { get => _byteArrayList.Value; }
+        public List<byte[]> ByteArrayList { get => _byteArrayList.Value; }
 
-        public List<string>? StringList() => _stringList.Value;
+        public List<string> StringList() => _stringList.Value;
     }
 
     public class Miss : CacheListFetchResponse

--- a/src/Momento.Sdk.Incubating/Responses/CacheListFetchResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheListFetchResponse.cs
@@ -38,23 +38,7 @@ public abstract class CacheListFetchResponse
 
     public class Miss : CacheListFetchResponse
     {
-        protected readonly Lazy<List<byte[]>?> _byteArrayList;
-        protected readonly Lazy<List<string>?> _stringList;
-        public Miss()
-        {
-            _byteArrayList = new(() =>
-            {
-                return null;
-            });
 
-            _stringList = new(() =>
-            {
-                return null;
-            });
-        }
-        public List<byte[]>? ByteArrayList { get => _byteArrayList.Value; }
-
-        public List<string>? StringList() => _stringList.Value;
     }
 
     public class Error : CacheListFetchResponse

--- a/src/Momento.Sdk.Incubating/Responses/CacheListPopBackResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheListPopBackResponse.cs
@@ -26,16 +26,7 @@ public abstract class CacheListPopBackResponse
 
     public class Miss : CacheListPopBackResponse
     {
-        public Miss() { }
-        public byte[]? ByteArray
-        {
-            get
-            {
-                return null;
-            }
-        }
 
-        public string? String() => null;
     }
 
     public class Error : CacheListPopBackResponse

--- a/src/Momento.Sdk.Incubating/Responses/CacheListPopFrontResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheListPopFrontResponse.cs
@@ -27,16 +27,7 @@ public abstract class CacheListPopFrontResponse
 
     public class Miss : CacheListPopFrontResponse
     {
-        public Miss() { }
-        public byte[]? ByteArray
-        {
-            get
-            {
-                return null;
-            }
-        }
 
-        public string? String() => null;
     }
 
     public class Error : CacheListPopFrontResponse

--- a/src/Momento.Sdk.Incubating/Responses/CacheSetFetchResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheSetFetchResponse.cs
@@ -14,9 +14,9 @@ public abstract class CacheSetFetchResponse
 {
     public class Hit : CacheSetFetchResponse
     {
-        protected readonly RepeatedField<ByteString>? elements;
-        protected readonly Lazy<HashSet<byte[]>?> _byteArraySet;
-        protected readonly Lazy<HashSet<string>?> _stringSet;
+        protected readonly RepeatedField<ByteString> elements;
+        protected readonly Lazy<HashSet<byte[]>> _byteArraySet;
+        protected readonly Lazy<HashSet<string>> _stringSet;
 
         public Hit(_SetFetchResponse response)
         {
@@ -36,30 +36,14 @@ public abstract class CacheSetFetchResponse
             });
         }
 
-        public HashSet<byte[]>? ByteArraySet { get => _byteArraySet.Value; }
+        public HashSet<byte[]> ByteArraySet { get => _byteArraySet.Value; }
 
-        public HashSet<string>? StringSet() => _stringSet.Value;
+        public HashSet<string> StringSet() => _stringSet.Value;
     }
 
     public class Miss : CacheSetFetchResponse
     {
-        protected readonly Lazy<HashSet<byte[]>?> _byteArraySet;
-        protected readonly Lazy<HashSet<string>?> _stringSet;
-        public Miss()
-        {
-            _byteArraySet = new(() =>
-            {
-                return null;
-            });
 
-            _stringSet = new(() =>
-            {
-                return null;
-            });
-        }
-        public HashSet<byte[]>? ByteArraySet { get => _byteArraySet.Value; }
-
-        public HashSet<string>? StringSet() => _stringSet.Value;
     }
 
     public class Error : CacheSetFetchResponse

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
@@ -1,8 +1,6 @@
+using Momento.Sdk.Incubating.Responses;
 using Momento.Sdk.Internal.ExtensionMethods;
 using Momento.Sdk.Responses;
-using Momento.Sdk.Incubating.Responses;
-using Google.Protobuf.WellKnownTypes;
-using System.Collections.Generic;
 
 namespace Momento.Sdk.Incubating.Tests;
 
@@ -730,9 +728,6 @@ public class DictionaryTest : TestBase
         var dictionaryName = Utils.NewGuidString();
         CacheDictionaryFetchResponse response = await client.DictionaryFetchAsync(cacheName, dictionaryName);
         Assert.True(response is CacheDictionaryFetchResponse.Miss);
-        var nullResponse = (CacheDictionaryFetchResponse.Miss)response;
-        Assert.Null(nullResponse.ByteArrayByteArrayDictionary);
-        Assert.Null(nullResponse.StringStringDictionary());
     }
 
     [Fact]

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
@@ -528,9 +528,6 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Miss);
-        var missResponse = (CacheListFetchResponse.Miss)response;
-        Assert.Null(missResponse.ByteArrayList);
-        Assert.Null(missResponse.StringList());
     }
 
     [Fact]

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
@@ -476,9 +476,6 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         CacheListPopBackResponse response = await client.ListPopBackAsync(cacheName, listName);
         Assert.True(response is CacheListPopBackResponse.Miss);
-        var missResponse = (CacheListPopBackResponse.Miss)response;
-        Assert.Null(missResponse.ByteArray);
-        Assert.Null(missResponse.String());
     }
 
     [Fact]

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
@@ -424,9 +424,6 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         CacheListPopFrontResponse response = await client.ListPopFrontAsync(cacheName, listName);
         Assert.True(response is CacheListPopFrontResponse.Miss);
-        var missResponse = (CacheListPopFrontResponse.Miss)response;
-        Assert.Null(missResponse.ByteArray);
-        Assert.Null(missResponse.String());
     }
 
     [Fact]

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
@@ -1,9 +1,5 @@
-using Momento.Sdk.Internal.ExtensionMethods;
-using Momento.Sdk.Responses;
 using Momento.Sdk.Incubating.Responses;
-using System.Xml.Linq;
-using Google.Protobuf.WellKnownTypes;
-using Newtonsoft.Json.Linq;
+using Momento.Sdk.Internal.ExtensionMethods;
 
 namespace Momento.Sdk.Incubating.Tests;
 

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/SetTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/SetTest.cs
@@ -1,6 +1,6 @@
-using Momento.Sdk.Responses;
-using Momento.Sdk.Incubating.Responses;
 using System.Xml.Linq;
+using Momento.Sdk.Incubating.Responses;
+using Momento.Sdk.Responses;
 
 namespace Momento.Sdk.Incubating.Tests;
 
@@ -474,9 +474,6 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         CacheSetFetchResponse response = await client.SetFetchAsync(cacheName, setName);
         Assert.True(response is CacheSetFetchResponse.Miss);
-        var missResponse = (CacheSetFetchResponse.Miss)response;
-        Assert.Null(missResponse.ByteArraySet);
-        Assert.Null(missResponse.StringSet());
     }
 
     [Fact]


### PR DESCRIPTION
This fixes the data structure `*FetchResponse.Hit` classes to have non-nullable payload. Nullable payload was an artifact of the previous design. This PR also ensures all `*Response.Miss` classes are empty (ie have no fields), which was also an artifact of the previous design.

Closes #20 