### PR TITLE
chore: update example to latest sdk

### DIFF
--- a/examples/DictionaryExample/DictionaryExample.csproj
+++ b/examples/DictionaryExample/DictionaryExample.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="Momento.Sdk.Incubating" Version="0.2.0-alpha" />
+    <PackageReference Include="Momento.Sdk.Incubating" Version="0.2.1-alpha" />
   </ItemGroup>
 
 </Project>

--- a/examples/DictionaryExample/Program.cs
+++ b/examples/DictionaryExample/Program.cs
@@ -116,7 +116,7 @@ public class Driver
             dictionaryName: dictionaryName);
         if (fetchResponse is CacheDictionaryFetchResponse.Hit fetchHit)
         {
-            var dictionary = fetchHit.StringStringDictionary()!;
+            var dictionary = fetchHit.StringStringDictionary();
             _logger.LogInformation("");
             _logger.LogInformation($"Accessing an entry of {dictionaryName} using a native Dictionary: {dictionary["field1"]}");
 


### PR DESCRIPTION
This updates the example program to version 0.2.1-alpha, which includes fixes for the fetch response types.