### PR TITLE
feat: use `TimeSpan` for TTL and deadline; prefer `int` to `uint`

### DIFF
--- a/src/Momento.Sdk.Incubating/Momento.Sdk.Incubating.csproj
+++ b/src/Momento.Sdk.Incubating/Momento.Sdk.Incubating.csproj
@@ -34,7 +34,7 @@
 		<RepositoryUrl>https://github.com/momentohq/client-sdk-dotnet-incubating</RepositoryUrl>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Momento.Sdk" Version="0.32.2" />
+		<PackageReference Include="Momento.Sdk" Version="0.37.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/src/Momento.Sdk.Incubating/Responses/CacheGetBatchResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheGetBatchResponse.cs
@@ -22,7 +22,7 @@ public abstract class CacheGetBatchResponse
             {
                 if (response is CacheGetResponse.Hit hitResponse)
                 {
-                    ret.Add(hitResponse.String());
+                    ret.Add(hitResponse.ValueString);
                 }
                 else if (response is CacheGetResponse.Miss missResponse)
                 {
@@ -41,7 +41,7 @@ public abstract class CacheGetBatchResponse
                 {
                     if (response is CacheGetResponse.Hit hitResponse)
                     {
-                        ret.Add(hitResponse.ByteArray);
+                        ret.Add(hitResponse.ValueByteArray);
                     }
                     else if (response is CacheGetResponse.Miss missResponse)
                     {

--- a/src/Momento.Sdk.Incubating/SimpleCacheClientFactory.cs
+++ b/src/Momento.Sdk.Incubating/SimpleCacheClientFactory.cs
@@ -1,4 +1,5 @@
-using Microsoft.Extensions.Logging;
+using System;
+using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
 
 namespace Momento.Sdk.Incubating;
@@ -14,13 +15,12 @@ public class SimpleCacheClientFactory
     /// Instantiate an instance of the incubating Simple Cache Client.
     /// </summary>
     /// <param name="config">Configuration to use for the transport, retries, middlewares. See <see href="https://github.com/momentohq/client-sdk-dotnet/blob/main/src/Momento.Sdk/Config/Configurations.cs"/> for out-of-the-box configuration choices, eg <see href="https://github.com/momentohq/client-sdk-dotnet/blob/main/src/Momento.Sdk/Config/Configurations.cs#L22"/></param>
-    /// <param name="authToken">Momento JWT.</param>
-    /// <param name="defaultTtlSeconds">Default time to live for the item in cache.</param>
-    /// <param name="loggerFactory">Logger factory to create loggers for contained instances.</param>
+    /// <param name="authProvider">Momento JWT.</param>
+    /// <param name="defaultTtl">Default time to live for the item in cache.</param>
     /// <returns>An instance of the incubating Simple Cache Client.</returns>
-    public static SimpleCacheClient CreateClient(IConfiguration config, string authToken, uint defaultTtlSeconds, ILoggerFactory? loggerFactory = null)
+    public static SimpleCacheClient CreateClient(IConfiguration config, ICredentialProvider authProvider, TimeSpan defaultTtl)
     {
-        var simpleCacheClient = new Momento.Sdk.SimpleCacheClient(config, authToken, defaultTtlSeconds, loggerFactory);
-        return new SimpleCacheClient(simpleCacheClient, config, authToken, defaultTtlSeconds, loggerFactory);
+        var simpleCacheClient = new Momento.Sdk.SimpleCacheClient(config, authProvider, defaultTtl);
+        return new SimpleCacheClient(simpleCacheClient, config, authProvider, defaultTtl);
     }
 }

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/BatchTests.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/BatchTests.cs
@@ -1,8 +1,9 @@
 namespace Momento.Sdk.Incubating.Tests;
 
-using Momento.Sdk.Responses;
-using Momento.Sdk.Incubating.Responses;
+using System;
 using Momento.Sdk.Config;
+using Momento.Sdk.Incubating.Responses;
+using Momento.Sdk.Responses;
 
 [Collection("SimpleCacheClient")]
 public class BatchTests : TestBase
@@ -90,13 +91,13 @@ public class BatchTests : TestBase
     [Fact]
     public async Task GetBatchAsync_Failure()
     {
-        // Set very small timeout for dataClientOperationTimeoutMilliseconds
-        IConfiguration config = Configurations.Laptop.Latest;
+        // Set very small timeout for dataClientOperationTimeout
+        IConfiguration config = Configurations.Laptop.Latest();
         config = config.WithTransportStrategy(
             config.TransportStrategy.WithGrpcConfig(
-                config.TransportStrategy.GrpcConfig.WithDeadlineMilliseconds(1)));
+                config.TransportStrategy.GrpcConfig.WithDeadline(TimeSpan.FromMilliseconds(1))));
 
-        using SimpleCacheClient simpleCacheClient = SimpleCacheClientFactory.CreateClient(config, this.authToken, defaultTtlSeconds);
+        using SimpleCacheClient simpleCacheClient = SimpleCacheClientFactory.CreateClient(config, this.authProvider, defaultTtl);
         List<string> keys = new() { Utils.NewGuidString(), Utils.NewGuidString(), Utils.NewGuidString(), Utils.NewGuidString() };
         CacheGetBatchResponse response = await simpleCacheClient.GetBatchAsync(cacheName, keys);
         Assert.True(response is CacheGetBatchResponse.Error);
@@ -137,12 +138,12 @@ public class BatchTests : TestBase
         var getResponse = await client.GetAsync(cacheName, key1);
         Assert.True(getResponse is CacheGetResponse.Hit);
         var goodGetResponse = (CacheGetResponse.Hit)getResponse;
-        Assert.Equal(value1, goodGetResponse.ByteArray);
+        Assert.Equal(value1, goodGetResponse.ValueByteArray);
 
         getResponse = await client.GetAsync(cacheName, key2);
         Assert.True(getResponse is CacheGetResponse.Hit);
         goodGetResponse = (CacheGetResponse.Hit)getResponse;
-        Assert.Equal(value2, goodGetResponse.ByteArray);
+        Assert.Equal(value2, goodGetResponse.ValueByteArray);
     }
 
     [Fact]
@@ -178,11 +179,11 @@ public class BatchTests : TestBase
         var getResponse = await client.GetAsync(cacheName, key1);
         Assert.True(getResponse is CacheGetResponse.Hit);
         var goodGetResponse = (CacheGetResponse.Hit)getResponse;
-        Assert.Equal(value1, goodGetResponse.String());
+        Assert.Equal(value1, goodGetResponse.ValueString);
 
         getResponse = await client.GetAsync(cacheName, key2);
         Assert.True(getResponse is CacheGetResponse.Hit);
         goodGetResponse = (CacheGetResponse.Hit)getResponse;
-        Assert.Equal(value2, goodGetResponse.String());
+        Assert.Equal(value2, goodGetResponse.ValueString);
     }
 }

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
@@ -1,6 +1,6 @@
+using System;
 using Momento.Sdk.Incubating.Responses;
 using Momento.Sdk.Internal.ExtensionMethods;
-using Momento.Sdk.Responses;
 
 namespace Momento.Sdk.Incubating.Tests;
 
@@ -78,11 +78,11 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidByteArray();
         var value = Utils.NewGuidByteArray();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttlSeconds: 5);
+        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttl: TimeSpan.FromSeconds(5));
         Assert.True(setResponse is CacheDictionarySetResponse.Success);
         await Task.Delay(100);
 
-        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttlSeconds: 10);
+        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttl: TimeSpan.FromSeconds(10));
         Assert.True(setResponse is CacheDictionarySetResponse.Success);
         await Task.Delay(4900);
 
@@ -97,9 +97,9 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidByteArray();
         var value = Utils.NewGuidByteArray();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttlSeconds: 2);
+        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttl: TimeSpan.FromSeconds(2));
         Assert.True(setResponse is CacheDictionarySetResponse.Success);
-        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, true, ttlSeconds: 10);
+        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, true, ttl: TimeSpan.FromSeconds(10));
         Assert.True(setResponse is CacheDictionarySetResponse.Success);
         await Task.Delay(2000);
 
@@ -152,9 +152,9 @@ public class DictionaryTest : TestBase
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidString();
 
-        CacheDictionaryIncrementResponse resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, refreshTtl: false, ttlSeconds: 2);
+        CacheDictionaryIncrementResponse resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, refreshTtl: false, ttl: TimeSpan.FromSeconds(2));
         Assert.True(resp is CacheDictionaryIncrementResponse.Success);
-        resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, refreshTtl: true, ttlSeconds: 10);
+        resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, refreshTtl: true, ttl: TimeSpan.FromSeconds(10));
         Assert.True(resp is CacheDictionaryIncrementResponse.Success);
         await Task.Delay(2000);
 
@@ -169,11 +169,11 @@ public class DictionaryTest : TestBase
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidString();
 
-        CacheDictionaryIncrementResponse resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, refreshTtl: false, ttlSeconds: 5);
+        CacheDictionaryIncrementResponse resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, refreshTtl: false, ttl: TimeSpan.FromSeconds(5));
         Assert.True(resp is CacheDictionaryIncrementResponse.Success);
         await Task.Delay(100);
 
-        resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, refreshTtl: false, ttlSeconds: 10);
+        resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, refreshTtl: false, ttl: TimeSpan.FromSeconds(10));
         Assert.True(resp is CacheDictionaryIncrementResponse.Success);
         await Task.Delay(4900);
 
@@ -285,11 +285,11 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttlSeconds: 5);
+        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttl: TimeSpan.FromSeconds(5));
         Assert.True(setResponse is CacheDictionarySetResponse.Success);
         await Task.Delay(100);
 
-        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttlSeconds: 10);
+        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttl: TimeSpan.FromSeconds(10));
         Assert.True(setResponse is CacheDictionarySetResponse.Success);
         await Task.Delay(4900);
 
@@ -304,9 +304,9 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttlSeconds: 2);
+        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttl: TimeSpan.FromSeconds(2));
         Assert.True(setResponse is CacheDictionarySetResponse.Success);
-        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, true, ttlSeconds: 10);
+        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, true, ttl: TimeSpan.FromSeconds(10));
         Assert.True(setResponse is CacheDictionarySetResponse.Success);
         await Task.Delay(2000);
 
@@ -348,11 +348,11 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttlSeconds: 5);
+        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttl: TimeSpan.FromSeconds(5));
         Assert.True(setResponse is CacheDictionarySetResponse.Success);
         await Task.Delay(100);
 
-        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttlSeconds: 10);
+        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttl: TimeSpan.FromSeconds(10));
         Assert.True(setResponse is CacheDictionarySetResponse.Success);
         await Task.Delay(4900);
 
@@ -367,9 +367,9 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttlSeconds: 2);
+        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttl: TimeSpan.FromSeconds(2));
         Assert.True(setResponse is CacheDictionarySetResponse.Success);
-        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, true, ttlSeconds: 10);
+        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, true, ttl: TimeSpan.FromSeconds(10));
         Assert.True(setResponse is CacheDictionarySetResponse.Success);
         await Task.Delay(2000);
 
@@ -410,7 +410,7 @@ public class DictionaryTest : TestBase
 
         var items = new Dictionary<byte[], byte[]>() { { field1, value1 }, { field2, value2 } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, items, false, 10);
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, items, false, TimeSpan.FromSeconds(10));
 
         CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field1);
         Assert.True(getResponse is CacheDictionaryGetResponse.Hit);
@@ -429,10 +429,10 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
         var content = new Dictionary<byte[], byte[]>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttlSeconds: 5);
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttl: TimeSpan.FromSeconds(5));
         await Task.Delay(100);
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttlSeconds: 10);
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttl: TimeSpan.FromSeconds(10));
         await Task.Delay(4900);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
@@ -447,8 +447,8 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
         var content = new Dictionary<byte[], byte[]>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttlSeconds: 2);
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, true, ttlSeconds: 10);
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttl: TimeSpan.FromSeconds(2));
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, true, ttl: TimeSpan.FromSeconds(10));
         await Task.Delay(2000);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
@@ -488,7 +488,7 @@ public class DictionaryTest : TestBase
 
         var items = new Dictionary<string, string>() { { field1, value1 }, { field2, value2 } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, items, false, 10);
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, items, false, TimeSpan.FromSeconds(10));
 
         CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field1);
         Assert.True(getResponse is CacheDictionaryGetResponse.Hit);
@@ -507,10 +507,10 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidString();
         var content = new Dictionary<string, string>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttlSeconds: 5);
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttl: TimeSpan.FromSeconds(5));
         await Task.Delay(100);
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttlSeconds: 10);
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttl: TimeSpan.FromSeconds(10));
         await Task.Delay(4900);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
@@ -525,8 +525,8 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidString();
         var content = new Dictionary<string, string>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttlSeconds: 2);
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, true, ttlSeconds: 10);
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttl: TimeSpan.FromSeconds(2));
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, true, ttl: TimeSpan.FromSeconds(10));
         await Task.Delay(2000);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
@@ -566,7 +566,7 @@ public class DictionaryTest : TestBase
 
         var items = new Dictionary<string, byte[]>() { { field1, value1 }, { field2, value2 } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, items, false, 10);
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, items, false, TimeSpan.FromSeconds(10));
 
         CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field1);
         Assert.True(getResponse is CacheDictionaryGetResponse.Hit);
@@ -585,10 +585,10 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
         var content = new Dictionary<string, byte[]>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttlSeconds: 5);
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttl: TimeSpan.FromSeconds(5));
         await Task.Delay(100);
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttlSeconds: 10);
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttl: TimeSpan.FromSeconds(10));
         await Task.Delay(4900);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
@@ -603,8 +603,8 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
         var content = new Dictionary<string, byte[]>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttlSeconds: 2);
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, true, ttlSeconds: 10);
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttl: TimeSpan.FromSeconds(2));
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, true, ttl: TimeSpan.FromSeconds(10));
         await Task.Delay(2000);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
@@ -656,8 +656,8 @@ public class DictionaryTest : TestBase
         var value2 = Utils.NewGuidByteArray();
         var field3 = Utils.NewGuidByteArray();
 
-        await client.DictionarySetAsync(cacheName, dictionaryName, field1, value1, false, 10);
-        await client.DictionarySetAsync(cacheName, dictionaryName, field2, value2, false, 10);
+        await client.DictionarySetAsync(cacheName, dictionaryName, field1, value1, false, TimeSpan.FromSeconds(10));
+        await client.DictionarySetAsync(cacheName, dictionaryName, field2, value2, false, TimeSpan.FromSeconds(10));
 
         CacheDictionaryGetBatchResponse response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, new byte[][] { field1, field2, field3 });
         Assert.True(response is CacheDictionaryGetBatchResponse.Success);
@@ -727,8 +727,8 @@ public class DictionaryTest : TestBase
         var value2 = Utils.NewGuidString();
         var field3 = Utils.NewGuidString();
 
-        await client.DictionarySetAsync(cacheName, dictionaryName, field1, value1, false, 10);
-        await client.DictionarySetAsync(cacheName, dictionaryName, field2, value2, false, 10);
+        await client.DictionarySetAsync(cacheName, dictionaryName, field1, value1, false, TimeSpan.FromSeconds(10));
+        await client.DictionarySetAsync(cacheName, dictionaryName, field2, value2, false, TimeSpan.FromSeconds(10));
 
         CacheDictionaryGetBatchResponse response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, new string[] { field1, field2, field3 });
         Assert.True(response is CacheDictionaryGetBatchResponse.Success);
@@ -767,8 +767,8 @@ public class DictionaryTest : TestBase
             {field2, value2}
         };
 
-        await client.DictionarySetAsync(cacheName, dictionaryName, field1, value1, true, ttlSeconds: 10);
-        await client.DictionarySetAsync(cacheName, dictionaryName, field2, value2, true, ttlSeconds: 10);
+        await client.DictionarySetAsync(cacheName, dictionaryName, field1, value1, true, ttl: TimeSpan.FromSeconds(10));
+        await client.DictionarySetAsync(cacheName, dictionaryName, field2, value2, true, ttl: TimeSpan.FromSeconds(10));
 
         CacheDictionaryFetchResponse fetchResponse = await client.DictionaryFetchAsync(cacheName, dictionaryName);
 
@@ -793,8 +793,8 @@ public class DictionaryTest : TestBase
             {field2, value2}
         };
 
-        await client.DictionarySetAsync(cacheName, dictionaryName, field1, value1, true, ttlSeconds: 10);
-        await client.DictionarySetAsync(cacheName, dictionaryName, field2, value2, true, ttlSeconds: 10);
+        await client.DictionarySetAsync(cacheName, dictionaryName, field1, value1, true, ttl: TimeSpan.FromSeconds(10));
+        await client.DictionarySetAsync(cacheName, dictionaryName, field2, value2, true, ttl: TimeSpan.FromSeconds(10));
 
         CacheDictionaryFetchResponse fetchResponse = await client.DictionaryFetchAsync(cacheName, dictionaryName);
 
@@ -819,8 +819,8 @@ public class DictionaryTest : TestBase
             {field2, value2}
         };
 
-        await client.DictionarySetAsync(cacheName, dictionaryName, field1, value1, true, ttlSeconds: 10);
-        await client.DictionarySetAsync(cacheName, dictionaryName, field2, value2, true, ttlSeconds: 10);
+        await client.DictionarySetAsync(cacheName, dictionaryName, field1, value1, true, ttl: TimeSpan.FromSeconds(10));
+        await client.DictionarySetAsync(cacheName, dictionaryName, field2, value2, true, ttl: TimeSpan.FromSeconds(10));
 
         CacheDictionaryFetchResponse fetchResponse = await client.DictionaryFetchAsync(cacheName, dictionaryName);
 

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/Fixtures.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/Fixtures.cs
@@ -1,3 +1,4 @@
+using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
 
 namespace Momento.Sdk.Incubating.Tests;
@@ -10,19 +11,18 @@ namespace Momento.Sdk.Incubating.Tests;
 public class SimpleCacheClientFixture : IDisposable
 {
     public SimpleCacheClient Client { get; private set; }
-    public string AuthToken { get; private set; }
+    public ICredentialProvider AuthProvider { get; private set; }
     public string CacheName { get; private set; }
 
-    public const uint DefaultTtlSeconds = 10;
+    public static TimeSpan DefaultTtl { get; private set; } = TimeSpan.FromSeconds(10);
 
     public SimpleCacheClientFixture()
     {
-        AuthToken = Environment.GetEnvironmentVariable("TEST_AUTH_TOKEN") ??
-            throw new NullReferenceException("TEST_AUTH_TOKEN environment variable must be set.");
+        AuthProvider = new EnvMomentoTokenProvider("TEST_AUTH_TOKEN");
         CacheName = Environment.GetEnvironmentVariable("TEST_CACHE_NAME") ??
             throw new NullReferenceException("TEST_CACHE_NAME environment variable must be set.");
         CacheName += "-incubating";
-        Client = SimpleCacheClientFactory.CreateClient(Configurations.Laptop.Latest, AuthToken, defaultTtlSeconds: DefaultTtlSeconds);
+        Client = SimpleCacheClientFactory.CreateClient(Configurations.Laptop.Latest(), AuthProvider, defaultTtl: DefaultTtl);
 
 
         try

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
@@ -60,10 +60,10 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        await client.ListPushFrontAsync(cacheName, listName, value, false, ttlSeconds: 5);
+        await client.ListPushFrontAsync(cacheName, listName, value, false, ttl: TimeSpan.FromSeconds(5));
         await Task.Delay(100);
 
-        await client.ListPushFrontAsync(cacheName, listName, value, false, ttlSeconds: 10);
+        await client.ListPushFrontAsync(cacheName, listName, value, false, ttl: TimeSpan.FromSeconds(10));
         await Task.Delay(4900);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -76,8 +76,8 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        await client.ListPushFrontAsync(cacheName, listName, value, false, ttlSeconds: 2);
-        await client.ListPushFrontAsync(cacheName, listName, value, true, ttlSeconds: 10);
+        await client.ListPushFrontAsync(cacheName, listName, value, false, ttl: TimeSpan.FromSeconds(2));
+        await client.ListPushFrontAsync(cacheName, listName, value, true, ttl: TimeSpan.FromSeconds(10));
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -143,10 +143,10 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        await client.ListPushFrontAsync(cacheName, listName, value, false, ttlSeconds: 5);
+        await client.ListPushFrontAsync(cacheName, listName, value, false, ttl: TimeSpan.FromSeconds(5));
         await Task.Delay(100);
 
-        await client.ListPushFrontAsync(cacheName, listName, value, false, ttlSeconds: 10);
+        await client.ListPushFrontAsync(cacheName, listName, value, false, ttl: TimeSpan.FromSeconds(10));
         await Task.Delay(4900);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -159,8 +159,8 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        await client.ListPushFrontAsync(cacheName, listName, value, false, ttlSeconds: 2);
-        await client.ListPushFrontAsync(cacheName, listName, value, true, ttlSeconds: 10);
+        await client.ListPushFrontAsync(cacheName, listName, value, false, ttl: TimeSpan.FromSeconds(2));
+        await client.ListPushFrontAsync(cacheName, listName, value, true, ttl: TimeSpan.FromSeconds(10));
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -226,10 +226,10 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        await client.ListPushBackAsync(cacheName, listName, value, false, ttlSeconds: 5);
+        await client.ListPushBackAsync(cacheName, listName, value, false, ttl: TimeSpan.FromSeconds(5));
         await Task.Delay(100);
 
-        await client.ListPushBackAsync(cacheName, listName, value, false, ttlSeconds: 10);
+        await client.ListPushBackAsync(cacheName, listName, value, false, ttl: TimeSpan.FromSeconds(10));
         await Task.Delay(4900);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -242,8 +242,8 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        await client.ListPushBackAsync(cacheName, listName, value, false, ttlSeconds: 2);
-        await client.ListPushBackAsync(cacheName, listName, value, true, ttlSeconds: 10);
+        await client.ListPushBackAsync(cacheName, listName, value, false, ttl: TimeSpan.FromSeconds(2));
+        await client.ListPushBackAsync(cacheName, listName, value, true, ttl: TimeSpan.FromSeconds(10));
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -381,10 +381,10 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        await client.ListPushBackAsync(cacheName, listName, value, false, ttlSeconds: 5);
+        await client.ListPushBackAsync(cacheName, listName, value, false, ttl: TimeSpan.FromSeconds(5));
         await Task.Delay(100);
 
-        await client.ListPushBackAsync(cacheName, listName, value, false, ttlSeconds: 10);
+        await client.ListPushBackAsync(cacheName, listName, value, false, ttl: TimeSpan.FromSeconds(10));
         await Task.Delay(4900);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -397,8 +397,8 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        await client.ListPushBackAsync(cacheName, listName, value, false, ttlSeconds: 2);
-        await client.ListPushBackAsync(cacheName, listName, value, true, ttlSeconds: 10);
+        await client.ListPushBackAsync(cacheName, listName, value, false, ttl: TimeSpan.FromSeconds(2));
+        await client.ListPushBackAsync(cacheName, listName, value, true, ttl: TimeSpan.FromSeconds(10));
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -539,8 +539,8 @@ public class ListTest : TestBase
         var field2 = Utils.NewGuidString();
         var contentList = new List<string>() { field1, field2 };
 
-        await client.ListPushFrontAsync(cacheName, listName, field2, true, ttlSeconds: 10);
-        await client.ListPushFrontAsync(cacheName, listName, field1, true, ttlSeconds: 10);
+        await client.ListPushFrontAsync(cacheName, listName, field2, true, ttl: TimeSpan.FromSeconds(10));
+        await client.ListPushFrontAsync(cacheName, listName, field1, true, ttl: TimeSpan.FromSeconds(10));
 
         CacheListFetchResponse fetchResponse = await client.ListFetchAsync(cacheName, listName);
         Assert.True(fetchResponse is CacheListFetchResponse.Hit);
@@ -557,8 +557,8 @@ public class ListTest : TestBase
         var field2 = Utils.NewGuidByteArray();
         var contentList = new List<byte[]> { field1, field2 };
 
-        await client.ListPushFrontAsync(cacheName, listName, field2, true, ttlSeconds: 10);
-        await client.ListPushFrontAsync(cacheName, listName, field1, true, ttlSeconds: 10);
+        await client.ListPushFrontAsync(cacheName, listName, field2, true, ttl: TimeSpan.FromSeconds(10));
+        await client.ListPushFrontAsync(cacheName, listName, field1, true, ttl: TimeSpan.FromSeconds(10));
 
         CacheListFetchResponse fetchResponse = await client.ListFetchAsync(cacheName, listName);
         Assert.True(fetchResponse is CacheListFetchResponse.Hit);
@@ -590,7 +590,7 @@ public class ListTest : TestBase
         // Add elements to the list
         foreach (var value in list)
         {
-            await client.ListPushBackAsync(cacheName, listName, value, true, ttlSeconds: 60);
+            await client.ListPushBackAsync(cacheName, listName, value, true, ttl: TimeSpan.FromSeconds(60));
         }
 
         await client.ListPushBackAsync(cacheName, listName, valueOfInterest, false);
@@ -655,7 +655,7 @@ public class ListTest : TestBase
         // Add elements to the list
         foreach (var value in list)
         {
-            await client.ListPushBackAsync(cacheName, listName, value, true, ttlSeconds: 60);
+            await client.ListPushBackAsync(cacheName, listName, value, true, ttl: TimeSpan.FromSeconds(60));
         }
 
         await client.ListPushBackAsync(cacheName, listName, valueOfInterest, false);

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/SetTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/SetTest.cs
@@ -45,11 +45,11 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidByteArray();
 
-        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, false, ttlSeconds: 5);
+        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, false, ttl: TimeSpan.FromSeconds(5));
         Assert.True(response is CacheSetAddResponse.Success);
         await Task.Delay(100);
 
-        response = await client.SetAddAsync(cacheName, setName, element, false, ttlSeconds: 10);
+        response = await client.SetAddAsync(cacheName, setName, element, false, ttl: TimeSpan.FromSeconds(10));
         Assert.True(response is CacheSetAddResponse.Success);
         await Task.Delay(4900);
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
@@ -62,9 +62,9 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidByteArray();
 
-        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, false, ttlSeconds: 2);
+        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, false, ttl: TimeSpan.FromSeconds(2));
         Assert.True(response is CacheSetAddResponse.Success);
-        await client.SetAddAsync(cacheName, setName, element, true, ttlSeconds: 10);
+        await client.SetAddAsync(cacheName, setName, element, true, ttl: TimeSpan.FromSeconds(10));
         await Task.Delay(2000);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
@@ -106,11 +106,11 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidString();
 
-        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, false, ttlSeconds: 5);
+        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, false, ttl: TimeSpan.FromSeconds(5));
         Assert.True(response is CacheSetAddResponse.Success);
         await Task.Delay(100);
 
-        response = await client.SetAddAsync(cacheName, setName, element, false, ttlSeconds: 10);
+        response = await client.SetAddAsync(cacheName, setName, element, false, ttl: TimeSpan.FromSeconds(10));
         Assert.True(response is CacheSetAddResponse.Success);
         await Task.Delay(4900);
 
@@ -124,9 +124,9 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidString();
 
-        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, false, ttlSeconds: 2);
+        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, false, ttl: TimeSpan.FromSeconds(2));
         Assert.True(response is CacheSetAddResponse.Success);
-        response = await client.SetAddAsync(cacheName, setName, element, true, ttlSeconds: 10);
+        response = await client.SetAddAsync(cacheName, setName, element, true, ttl: TimeSpan.FromSeconds(10));
         Assert.True(response is CacheSetAddResponse.Success);
         await Task.Delay(2000);
 
@@ -164,7 +164,7 @@ public class SetTest : TestBase
         var element2 = Utils.NewGuidByteArray();
         var content = new List<byte[]>() { element1, element2 };
 
-        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, false, 10);
+        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, false, TimeSpan.FromSeconds(10));
         Assert.True(response is CacheSetAddBatchResponse.Success);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
@@ -183,11 +183,11 @@ public class SetTest : TestBase
         var element = Utils.NewGuidByteArray();
         var content = new List<byte[]>() { element };
 
-        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, false, ttlSeconds: 5);
+        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, false, ttl: TimeSpan.FromSeconds(5));
         Assert.True(response is CacheSetAddBatchResponse.Success);
         await Task.Delay(100);
 
-        response = await client.SetAddBatchAsync(cacheName, setName, content, false, ttlSeconds: 10);
+        response = await client.SetAddBatchAsync(cacheName, setName, content, false, ttl: TimeSpan.FromSeconds(10));
         Assert.True(response is CacheSetAddBatchResponse.Success);
         await Task.Delay(4900);
 
@@ -202,9 +202,9 @@ public class SetTest : TestBase
         var element = Utils.NewGuidByteArray();
         var content = new List<byte[]>() { element };
 
-        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, false, ttlSeconds: 2);
+        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, false, ttl: TimeSpan.FromSeconds(2));
         Assert.True(response is CacheSetAddBatchResponse.Success);
-        await client.SetAddBatchAsync(cacheName, setName, content, true, ttlSeconds: 10);
+        await client.SetAddBatchAsync(cacheName, setName, content, true, ttl: TimeSpan.FromSeconds(10));
         await Task.Delay(2000);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
@@ -244,7 +244,7 @@ public class SetTest : TestBase
         var element2 = Utils.NewGuidString();
         var content = new List<string>() { element1, element2 };
 
-        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, false, 10);
+        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, false, TimeSpan.FromSeconds(10));
         Assert.True(response is CacheSetAddBatchResponse.Success);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
@@ -263,11 +263,11 @@ public class SetTest : TestBase
         var element = Utils.NewGuidString();
         var content = new List<string>() { element };
 
-        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, false, ttlSeconds: 5);
+        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, false, ttl: TimeSpan.FromSeconds(5));
         Assert.True(response is CacheSetAddBatchResponse.Success);
         await Task.Delay(100);
 
-        response = await client.SetAddBatchAsync(cacheName, setName, content, false, ttlSeconds: 10);
+        response = await client.SetAddBatchAsync(cacheName, setName, content, false, ttl: TimeSpan.FromSeconds(10));
         Assert.True(response is CacheSetAddBatchResponse.Success);
         await Task.Delay(4900);
 
@@ -282,9 +282,9 @@ public class SetTest : TestBase
         var element = Utils.NewGuidString();
         var content = new List<string>() { element };
 
-        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, false, ttlSeconds: 2);
+        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, false, ttl: TimeSpan.FromSeconds(2));
         Assert.True(response is CacheSetAddBatchResponse.Success);
-        response = await client.SetAddBatchAsync(cacheName, setName, content, true, ttlSeconds: 10);
+        response = await client.SetAddBatchAsync(cacheName, setName, content, true, ttl: TimeSpan.FromSeconds(10));
         Assert.True(response is CacheSetAddBatchResponse.Success);
         await Task.Delay(2000);
 

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/TestBase.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/TestBase.cs
@@ -1,16 +1,18 @@
+using Momento.Sdk.Auth;
+
 namespace Momento.Sdk.Incubating.Tests;
 
 public class TestBase
 {
     protected readonly SimpleCacheClient client;
     protected readonly string cacheName;
-    protected readonly string authToken;
-    protected const uint defaultTtlSeconds = SimpleCacheClientFixture.DefaultTtlSeconds;
+    protected readonly ICredentialProvider authProvider;
+    protected readonly TimeSpan defaultTtl = SimpleCacheClientFixture.DefaultTtl;
 
     public TestBase(SimpleCacheClientFixture fixture)
     {
         this.client = fixture.Client;
         this.cacheName = fixture.CacheName;
-        this.authToken = fixture.AuthToken;
+        this.authProvider = fixture.AuthProvider;
     }
 }


### PR DESCRIPTION
This updates the SDK to use `TimeSpan` instead of bare integer types to specify TTL and deadline. We already made this change to the production SDK here
https://github.com/momentohq/client-sdk-dotnet/pull/286.

This also changes the `truncate` parameter to `ListPush` to use `int` instead of `uint` for CLS compliance.