### PR TITLE
feat: add list delete

### DIFF
--- a/src/Momento.Sdk.Incubating/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk.Incubating/Internal/ScsDataClient.cs
@@ -70,7 +70,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         {
             if (response is CacheGetResponse.Error errorResponse)
             {
-                return new CacheGetBatchResponse.Error(errorResponse.Exception);
+                return new CacheGetBatchResponse.Error(errorResponse.InnerException);
             }
         }
 

--- a/src/Momento.Sdk.Incubating/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk.Incubating/Internal/ScsDataClient.cs
@@ -826,4 +826,29 @@ internal sealed class ScsDataClient : ScsDataClientBase
         }
         return new CacheListLengthResponse.Success(response);
     }
+
+    public async Task<CacheListDeleteResponse> ListDeleteAsync(string cacheName, string listName)
+    {
+        _ListEraseRequest request = new()
+        {
+            ListName = listName.ToByteString(),
+            All = new()
+        };
+        _ListEraseResponse response;
+
+        try
+        {
+            response = await this.grpcManager.Client.ListEraseAsync(request, new CallOptions(headers: MetadataWithCache(cacheName), deadline: CalculateDeadline()));
+        }
+        catch (Exception e)
+        {
+            var exc = _exceptionMapper.Convert(e);
+            if (exc.TransportDetails != null)
+            {
+                exc.TransportDetails.Grpc.Metadata = MetadataWithCache(cacheName);
+            }
+            return new CacheListDeleteResponse.Error(exc);
+        }
+        return new CacheListDeleteResponse.Success();
+    }
 }

--- a/src/Momento.Sdk.Incubating/Momento.Sdk.Incubating.csproj
+++ b/src/Momento.Sdk.Incubating/Momento.Sdk.Incubating.csproj
@@ -34,7 +34,7 @@
 		<RepositoryUrl>https://github.com/momentohq/client-sdk-dotnet-incubating</RepositoryUrl>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Momento.Sdk" Version="0.37.1" />
+		<PackageReference Include="Momento.Sdk" Version="0.38.1" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/src/Momento.Sdk.Incubating/Responses/CacheListDeleteResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheListDeleteResponse.cs
@@ -1,0 +1,36 @@
+using Momento.Sdk.Exceptions;
+
+namespace Momento.Sdk.Incubating.Responses;
+
+public abstract class CacheListDeleteResponse
+{
+    public class Success : CacheListDeleteResponse
+    {
+    }
+
+    public class Error : CacheListDeleteResponse
+    {
+        private readonly SdkException _error;
+        public Error(SdkException error)
+        {
+            _error = error;
+        }
+
+        public SdkException Exception
+        {
+            get => _error;
+        }
+
+        public MomentoErrorCode ErrorCode
+        {
+            get => _error.ErrorCode;
+        }
+
+        public string Message
+        {
+            get => $"{_error.MessageWrapper}: {_error.Message}";
+        }
+
+    }
+
+}

--- a/src/Momento.Sdk.Incubating/SimpleCacheClient.cs
+++ b/src/Momento.Sdk.Incubating/SimpleCacheClient.cs
@@ -1020,6 +1020,30 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.ListLengthAsync(cacheName, listName);
     }
 
+    /// <summary>
+    /// Remove the list from the cache.
+    ///
+    /// Performs a no-op if <paramref name="listName"/> does not exist.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to delete the list from.</param>
+    /// <param name="listName">Name of the list to delete.</param>
+    /// <returns>Task representing the result of the delete operation.</returns>
+    public async Task<CacheListDeleteResponse> ListDeleteAsync(string cacheName, string listName)
+    {
+        try
+        {
+            Utils.ArgumentNotNull(cacheName, nameof(cacheName));
+            Utils.ArgumentNotNull(listName, nameof(listName));
+        }
+        catch (ArgumentNullException e)
+        {
+            return new CacheListDeleteResponse.Error(new InvalidArgumentException(e.Message));
+        }
+
+
+        return await this.dataClient.ListDeleteAsync(cacheName, listName);
+    }
+
     /// <inheritdoc />
     public void Dispose()
     {


### PR DESCRIPTION
This adds the `ListDeleteAsync` command, which deletes an entire list
from the cache.

In the process of implementing this, we updated to the latest `Momento.Sdk` version. This version changed the way we propagate exceptions for `CacheGetBatchResponse`, so we update this here too.

Closes #29 