### PR TITLE
fix: remove unused field

### DIFF
--- a/src/Momento.Sdk.Incubating/Responses/CacheListLengthResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheListLengthResponse.cs
@@ -7,7 +7,6 @@ public abstract class CacheListLengthResponse
 {
     public class Success : CacheListLengthResponse
     {
-        public int ListLength { get; private set; }
         public int Length { get; private set; } = 0;
         public Success(_ListLengthResponse response)
         {


### PR DESCRIPTION
The field `CacheListLengthResponse.Hit.ListLength` was probably introduced by mistake in a refactor, is unused. We remove it here.