### PR TITLE
feat: return errors not exceptions

### DIFF
--- a/src/Momento.Sdk.Incubating/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk.Incubating/Internal/ScsDataClient.cs
@@ -271,7 +271,12 @@ internal sealed class ScsDataClient : ScsDataClientBase
         }
         catch (Exception e)
         {
-            throw _exceptionMapper.Convert(e);
+            var exc = _exceptionMapper.Convert(e);
+            if (exc.TransportDetails != null)
+            {
+                exc.TransportDetails.Grpc.Metadata = MetadataWithCache(cacheName);
+            }
+            return new CacheDictionaryIncrementResponse.Error(exc);
         }
         return new CacheDictionaryIncrementResponse.Success(response);
     }

--- a/src/Momento.Sdk.Incubating/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk.Incubating/Internal/ScsDataClient.cs
@@ -6,7 +6,6 @@ using Google.Protobuf;
 using Grpc.Core;
 using Momento.Protos.CacheClient;
 using Momento.Sdk.Config;
-using Momento.Sdk.Exceptions;
 using Momento.Sdk.Incubating.Responses;
 using Momento.Sdk.Internal;
 using Momento.Sdk.Internal.ExtensionMethods;

--- a/src/Momento.Sdk.Incubating/SimpleCacheClient.cs
+++ b/src/Momento.Sdk.Incubating/SimpleCacheClient.cs
@@ -356,7 +356,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     ///
     /// <para>Incrementing the value of a missing field sets the value to <paramref name="amount"/>.</para>
     /// <para>Incrementing a value that was not set using this method or not the string representation of an integer
-    /// results in throwing a <see cref="FailedPreconditionException"/>.</para>
+    /// results in an error with <see cref="FailedPreconditionException"/>.</para>
     /// </summary>
     /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, TimeSpan?)" path="remark"/>
     /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
@@ -369,19 +369,37 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <example>
     /// The following illustrates a typical workflow:
     /// <code>
-    /// var response = client.DictionaryIncrementAsync("my cache", "my dictionary", "counter", amount: 42, refreshTtl: false);
-    /// Console.WriteLine($"Current value is {response.Value}");
+    ///     var response = await client.DictionaryIncrementAsync(cacheName, "my dictionary", "counter", amount: 42, refreshTtl: false);
+    ///     if (response is CacheDictionaryIncrementResponse.Success success)
+    ///     {
+    ///         Console.WriteLine($"Current value is {success.Value}");
+    ///     }
+    ///     else if (response is CacheDictionaryIncrementResponse.Error error)
+    ///     {
+    ///         Console.WriteLine($"Got an error: {error.Message}");
+    ///     }
     ///
-    /// // Reset the counter. Note we use the string representation of an integer.
-    /// client.DictionarySetAsync("my cache", "my dictionary", "counter", "0", refreshTtl: false);
+    ///     // Reset the counter. Note we use the string representation of an integer.
+    ///     var setResponse = await client.DictionarySetAsync(cacheName, "my dictionary", "counter", "0", refreshTtl: false);
+    ///     if (setResponse is CacheDictionarySetResponse.Error) { /* handle error */ }
     ///
-    /// // Retrieve the counter. The integer is represented as a string.
-    /// var response = client.DictionaryGetAsync("my cache", "my dictionary", "counter");
-    /// Console.WriteLine(response.String());
+    ///     // Retrieve the counter. The integer is represented as a string.
+    ///     var getResponse = await client.DictionaryGetAsync(cacheName, "my dictionary", "counter");
+    ///     if (getResponse is CacheDictionaryGetResponse.Hit getHit)
+    ///     {
+    ///         Console.WriteLine(getHit.String());
+    ///     }
+    ///     else if (getResponse is CacheDictionaryGetResponse.Error) { /* handle error */ }
     ///
-    /// // Here we try incrementing a value that isn't an integer. This throws a <see cref="FailedPreconditionException"/>
-    /// client.DictionarySetAsync("my cache", "my dictionary", "counter", "0123ABC", refreshTtl: false);
-    /// var response = client.DictionaryIncrementAsync("my cache", "my dictionary", "counter", amount: 42, refreshTtl: false);
+    ///     // Here we try incrementing a value that isn't an integer. This results in an error with <see cref="FailedPreconditionException"/>
+    ///     setResponse = await client.DictionarySetAsync(cacheName, "my dictionary", "counter", "0123ABC", refreshTtl: false);
+    ///     if (setResponse is CacheDictionarySetResponse.Error) { /* handle error */ }
+    ///
+    ///     var incrementResponse = await client.DictionaryIncrementAsync(cacheName, "my dictionary", "counter", amount: 42, refreshTtl: false);
+    ///     if (incrementResponse is CacheDictionaryIncrementResponse.Error badIncrement)
+    ///     {
+    ///         Console.WriteLine($"Could not increment dictionary field: {badIncrement.Message}");
+    ///     }
     /// </code>
     /// </example>
     public async Task<CacheDictionaryIncrementResponse> DictionaryIncrementAsync(string cacheName, string dictionaryName, string field, bool refreshTtl, long amount = 1, TimeSpan? ttl = null)

--- a/src/Momento.Sdk.Incubating/SimpleCacheClient.cs
+++ b/src/Momento.Sdk.Incubating/SimpleCacheClient.cs
@@ -8,7 +8,6 @@ using Momento.Sdk.Config;
 using Momento.Sdk.Exceptions;
 using Momento.Sdk.Incubating.Internal;
 using Momento.Sdk.Incubating.Responses;
-using Momento.Sdk.Internal;
 using Momento.Sdk.Responses;
 using Utils = Momento.Sdk.Internal.Utils;
 

--- a/src/Momento.Sdk.Incubating/SimpleCacheClient.cs
+++ b/src/Momento.Sdk.Incubating/SimpleCacheClient.cs
@@ -843,6 +843,10 @@ public class SimpleCacheClient : ISimpleCacheClient
         {
             return new CacheListPushFrontResponse.Error(new InvalidArgumentException(e.Message));
         }
+        catch (ArgumentOutOfRangeException e)
+        {
+            return new CacheListPushFrontResponse.Error(new InvalidArgumentException(e.Message));
+        }
 
         return await this.dataClient.ListPushFrontAsync(cacheName, listName, value, refreshTtl, truncateBackToSize, ttl);
     }
@@ -858,6 +862,10 @@ public class SimpleCacheClient : ISimpleCacheClient
             Utils.ArgumentStrictlyPositive(truncateBackToSize, nameof(truncateBackToSize));
         }
         catch (ArgumentNullException e)
+        {
+            return new CacheListPushFrontResponse.Error(new InvalidArgumentException(e.Message));
+        }
+        catch (ArgumentOutOfRangeException e)
         {
             return new CacheListPushFrontResponse.Error(new InvalidArgumentException(e.Message));
         }
@@ -889,6 +897,11 @@ public class SimpleCacheClient : ISimpleCacheClient
         {
             return new CacheListPushBackResponse.Error(new InvalidArgumentException(e.Message));
         }
+        catch (ArgumentOutOfRangeException e)
+        {
+            return new CacheListPushBackResponse.Error(new InvalidArgumentException(e.Message));
+        }
+
         return await this.dataClient.ListPushBackAsync(cacheName, listName, value, refreshTtl, truncateFrontToSize, ttl);
     }
 
@@ -903,6 +916,10 @@ public class SimpleCacheClient : ISimpleCacheClient
             Utils.ArgumentStrictlyPositive(truncateFrontToSize, nameof(truncateFrontToSize));
         }
         catch (ArgumentNullException e)
+        {
+            return new CacheListPushBackResponse.Error(new InvalidArgumentException(e.Message));
+        }
+        catch (ArgumentOutOfRangeException e)
         {
             return new CacheListPushBackResponse.Error(new InvalidArgumentException(e.Message));
         }

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/BatchTests.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/BatchTests.cs
@@ -13,7 +13,7 @@ public class BatchTests : TestBase
     }
 
     [Fact]
-    public async Task GetBatchAsync_NullCheckByteArray_ThrowsException()
+    public async Task GetBatchAsync_NullCheckByteArray_IsError()
     {
         CacheGetBatchResponse response = await client.GetBatchAsync(null!, new List<byte[]>());
         Assert.True(response is CacheGetBatchResponse.Error);
@@ -51,7 +51,7 @@ public class BatchTests : TestBase
     }
 
     [Fact]
-    public async Task GetBatchAsync_NullCheckString_ThrowsException()
+    public async Task GetBatchAsync_NullCheckString_IsError()
     {
         CacheGetBatchResponse response = await client.GetBatchAsync(null!, new List<string>());
         Assert.True(response is CacheGetBatchResponse.Error);
@@ -106,7 +106,7 @@ public class BatchTests : TestBase
     }
 
     [Fact]
-    public async Task SetBatchAsync_NullCheckByteArray_ThrowsException()
+    public async Task SetBatchAsync_NullCheckByteArray_IsError()
     {
         CacheSetBatchResponse response = await client.SetBatchAsync(null!, new Dictionary<byte[], byte[]>());
         Assert.True(response is CacheSetBatchResponse.Error);
@@ -147,7 +147,7 @@ public class BatchTests : TestBase
     }
 
     [Fact]
-    public async Task SetBatchAsync_NullCheckStrings_ThrowsException()
+    public async Task SetBatchAsync_NullCheckStrings_IsError()
     {
         CacheSetBatchResponse response = await client.SetBatchAsync(null!, new Dictionary<string, string>());
         Assert.True(response is CacheSetBatchResponse.Error);

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
@@ -15,7 +15,7 @@ public class DictionaryTest : TestBase
     [InlineData(null, "my-dictionary", new byte[] { 0x00 })]
     [InlineData("cache", null, new byte[] { 0x00 })]
     [InlineData("cache", "my-dictionary", null)]
-    public async Task DictionaryGetAsync_NullChecksFieldIsByteArray_ThrowsException(string cacheName, string dictionaryName, byte[] field)
+    public async Task DictionaryGetAsync_NullChecksFieldIsByteArray_IsError(string cacheName, string dictionaryName, byte[] field)
     {
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetResponse.Error);
@@ -27,7 +27,7 @@ public class DictionaryTest : TestBase
     [InlineData("cache", null, new byte[] { 0x00 }, new byte[] { 0x00 })]
     [InlineData("cache", "my-dictionary", null, new byte[] { 0x00 })]
     [InlineData("cache", "my-dictionary", new byte[] { 0x00 }, null)]
-    public async Task DictionarySetAsync_NullChecksFieldIsByteArrayValueIsByteArray_ThrowsException(string cacheName, string dictionaryName, byte[] field, byte[] value)
+    public async Task DictionarySetAsync_NullChecksFieldIsByteArrayValueIsByteArray_IsError(string cacheName, string dictionaryName, byte[] field, byte[] value)
     {
         CacheDictionarySetResponse response = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false);
         Assert.True(response is CacheDictionarySetResponse.Error);
@@ -112,7 +112,7 @@ public class DictionaryTest : TestBase
     [InlineData(null, "my-dictionary", "field")]
     [InlineData("cache", null, "field")]
     [InlineData("cache", "my-dictionary", null)]
-    public async Task DictionaryIncrementAsync_NullChecksFieldIsString_ThrowsException(string cacheName, string dictionaryName, string field)
+    public async Task DictionaryIncrementAsync_NullChecksFieldIsString_IsError(string cacheName, string dictionaryName, string field)
     {
         CacheDictionaryIncrementResponse response = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, refreshTtl: true);
         Assert.True(response is CacheDictionaryIncrementResponse.Error);
@@ -221,7 +221,7 @@ public class DictionaryTest : TestBase
     [InlineData(null, "my-dictionary", "my-field")]
     [InlineData("cache", null, "my-field")]
     [InlineData("cache", "my-dictionary", null)]
-    public async Task DictionaryGetAsync_NullChecksFieldIsString_ThrowsException(string cacheName, string dictionaryName, string field)
+    public async Task DictionaryGetAsync_NullChecksFieldIsString_IsError(string cacheName, string dictionaryName, string field)
     {
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetResponse.Error);
@@ -233,7 +233,7 @@ public class DictionaryTest : TestBase
     [InlineData("cache", null, "my-field", "my-value")]
     [InlineData("cache", "my-dictionary", null, "my-value")]
     [InlineData("cache", "my-dictionary", "my-field", null)]
-    public async Task DictionarySetAsync_NullChecksFieldIsStringValueIsString_ThrowsException(string cacheName, string dictionaryName, string field, string value)
+    public async Task DictionarySetAsync_NullChecksFieldIsStringValueIsString_IsError(string cacheName, string dictionaryName, string field, string value)
     {
         CacheDictionarySetResponse response = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false);
         Assert.True(response is CacheDictionarySetResponse.Error);
@@ -320,7 +320,7 @@ public class DictionaryTest : TestBase
     [InlineData("cache", null, "my-field", new byte[] { 0x00 })]
     [InlineData("cache", "my-dictionary", null, new byte[] { 0x00 })]
     [InlineData("cache", "my-dictionary", "my-field", null)]
-    public async Task DictionarySetAsync_NullChecksFieldIsStringValueIsByteArray_ThrowsException(string cacheName, string dictionaryName, string field, byte[] value)
+    public async Task DictionarySetAsync_NullChecksFieldIsStringValueIsByteArray_IsError(string cacheName, string dictionaryName, string field, byte[] value)
     {
         CacheDictionarySetResponse response = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false);
         Assert.True(response is CacheDictionarySetResponse.Error);
@@ -379,7 +379,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_NullChecksFieldIsByteArrayValueIsByteArray_ThrowsException()
+    public async Task DictionarySetBatchAsync_NullChecksFieldIsByteArrayValueIsByteArray_IsError()
     {
         var dictionaryName = Utils.NewGuidString();
         var dictionary = new Dictionary<byte[], byte[]>();
@@ -457,7 +457,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_NullChecksFieldsAreStringValuesAreString_ThrowsException()
+    public async Task DictionarySetBatchAsync_NullChecksFieldsAreStringValuesAreString_IsError()
     {
         var dictionaryName = Utils.NewGuidString();
         var dictionary = new Dictionary<string, string>();
@@ -535,7 +535,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_NullChecksFieldsAreStringValuesAreByteArray_ThrowsException()
+    public async Task DictionarySetBatchAsync_NullChecksFieldsAreStringValuesAreByteArray_IsError()
     {
         var dictionaryName = Utils.NewGuidString();
         var dictionary = new Dictionary<string, string>();
@@ -613,7 +613,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionaryGetBatchAsync_NullChecksFieldsAreByteArray_ThrowsException()
+    public async Task DictionaryGetBatchAsync_NullChecksFieldsAreByteArray_IsError()
     {
         var dictionaryName = Utils.NewGuidString();
         var testData = new byte[][][] { new byte[][] { Utils.NewGuidByteArray(), Utils.NewGuidByteArray() }, new byte[][] { Utils.NewGuidByteArray(), null! } };
@@ -685,7 +685,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionaryGetBatchAsync_NullChecksFieldsAreString_ThrowsException()
+    public async Task DictionaryGetBatchAsync_NullChecksFieldsAreString_IsError()
     {
         var dictionaryName = Utils.NewGuidString();
         var testData = new string[][] { new string[] { Utils.NewGuidString(), Utils.NewGuidString() }, new string[] { Utils.NewGuidString(), null! } };
@@ -739,7 +739,7 @@ public class DictionaryTest : TestBase
     [Theory]
     [InlineData(null, "my-dictionary")]
     [InlineData("cache", null)]
-    public async Task DictionaryFetchAsync_NullChecks_ThrowsException(string cacheName, string dictionaryName)
+    public async Task DictionaryFetchAsync_NullChecks_IsError(string cacheName, string dictionaryName)
     {
         CacheDictionaryFetchResponse response = await client.DictionaryFetchAsync(cacheName, dictionaryName);
         Assert.True(response is CacheDictionaryFetchResponse.Error);
@@ -842,7 +842,7 @@ public class DictionaryTest : TestBase
     [Theory]
     [InlineData(null, "my-dictionary")]
     [InlineData("my-cache", null)]
-    public async Task DictionaryDeleteAsync_NullChecks_ThrowsException(string cacheName, string dictionaryName)
+    public async Task DictionaryDeleteAsync_NullChecks_IsError(string cacheName, string dictionaryName)
     {
         CacheDictionaryDeleteResponse response = await client.DictionaryDeleteAsync(cacheName, dictionaryName);
         Assert.True(response is CacheDictionaryDeleteResponse.Error);
@@ -875,7 +875,7 @@ public class DictionaryTest : TestBase
     [InlineData(null, "my-dictionary", new byte[] { 0x00 })]
     [InlineData("my-cache", null, new byte[] { 0x00 })]
     [InlineData("my-cache", "my-dictionary", null)]
-    public async Task DictionaryRemoveFieldAsync_NullChecksFieldIsByteArray_ThrowsException(string cacheName, string dictionaryName, byte[] field)
+    public async Task DictionaryRemoveFieldAsync_NullChecksFieldIsByteArray_IsError(string cacheName, string dictionaryName, byte[] field)
     {
         CacheDictionaryRemoveFieldResponse response = await client.DictionaryRemoveFieldAsync(cacheName, dictionaryName, field);
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryRemoveFieldResponse.Error)response).ErrorCode);
@@ -885,7 +885,7 @@ public class DictionaryTest : TestBase
     [InlineData(null, "my-dictionary", "my-field")]
     [InlineData("my-cache", null, "my-field")]
     [InlineData("my-cache", "my-dictionary", null)]
-    public async Task DictionaryRemoveFieldAsync_NullChecksFieldIsString_ThrowsException(string cacheName, string dictionaryName, string field)
+    public async Task DictionaryRemoveFieldAsync_NullChecksFieldIsString_IsError(string cacheName, string dictionaryName, string field)
     {
         CacheDictionaryRemoveFieldResponse response = await client.DictionaryRemoveFieldAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryRemoveFieldResponse.Error);
@@ -937,7 +937,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionaryRemoveFieldsAsync_NullChecksFieldsAreByteArray_ThrowsException()
+    public async Task DictionaryRemoveFieldsAsync_NullChecksFieldsAreByteArray_IsError()
     {
         var dictionaryName = Utils.NewGuidString();
         var testData = new byte[][][] { new byte[][] { Utils.NewGuidByteArray(), Utils.NewGuidByteArray() }, new byte[][] { Utils.NewGuidByteArray(), null! } };
@@ -990,7 +990,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionaryRemoveFieldsAsync_NullChecksFieldsAreString_ThrowsException()
+    public async Task DictionaryRemoveFieldsAsync_NullChecksFieldsAreString_IsError()
     {
         var dictionaryName = Utils.NewGuidString();
         var testData = new string[][] { new string[] { Utils.NewGuidString(), Utils.NewGuidString() }, new string[] { Utils.NewGuidString(), null! } };

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
@@ -208,13 +208,17 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionaryIncrementAsync_FailedPrecondition_ThrowsException()
+    public async Task DictionaryIncrementAsync_FailedPrecondition_IsError()
     {
         var dictionaryName = Utils.NewGuidString();
         var fieldName = Utils.NewGuidString();
 
-        await client.DictionarySetAsync(cacheName, dictionaryName, fieldName, "abcxyz", false);
-        await Assert.ThrowsAsync<FailedPreconditionException>(async () => await client.DictionaryIncrementAsync(cacheName, dictionaryName, fieldName, amount: 1, refreshTtl: true));
+        var setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, fieldName, "abcxyz", false);
+        Assert.True(setResponse is CacheDictionarySetResponse.Success);
+
+        var dictionaryIncrementResponse = await client.DictionaryIncrementAsync(cacheName, dictionaryName, fieldName, refreshTtl: false);
+        Assert.True(dictionaryIncrementResponse is CacheDictionaryIncrementResponse.Error);
+        Assert.Equal(MomentoErrorCode.FAILED_PRECONDITION_ERROR, ((CacheDictionaryIncrementResponse.Error)dictionaryIncrementResponse).ErrorCode);
     }
 
     [Theory]

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
@@ -14,7 +14,7 @@ public class ListTest : TestBase
     [InlineData(null, "my-list", new byte[] { 0x00 })]
     [InlineData("cache", null, new byte[] { 0x00 })]
     [InlineData("cache", "my-list", null)]
-    public async Task ListPushFrontAsync_NullChecksByteArray_ThrowsException(string cacheName, string listName, byte[] value)
+    public async Task ListPushFrontAsync_NullChecksByteArray_IsError(string cacheName, string listName, byte[] value)
     {
         CacheListPushFrontResponse response = await client.ListPushFrontAsync(cacheName, listName, value, false);
         Assert.True(response is CacheListPushFrontResponse.Error);
@@ -87,16 +87,18 @@ public class ListTest : TestBase
     }
 
     [Fact]
-    public async Task ListPushFrontAsync_ValueIsByteArrayTruncateBackToSizeIsZero_ThrowsException()
+    public async Task ListPushFrontAsync_ValueIsByteArrayTruncateBackToSizeIsZero_IsError()
     {
-        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await client.ListPushFrontAsync("myCache", "listName", new byte[] { 0x00 }, false, truncateBackToSize: 0));
+        var response = await client.ListPushFrontAsync("myCache", "listName", new byte[] { 0x00 }, false, truncateBackToSize: 0);
+        Assert.True(response is CacheListPushFrontResponse.Error);
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListPushFrontResponse.Error)response).ErrorCode);
     }
 
     [Theory]
     [InlineData(null, "my-list", "my-value")]
     [InlineData("cache", null, "my-value")]
     [InlineData("cache", "my-list", null)]
-    public async Task ListPushFrontAsync_NullChecksString_ThrowsException(string cacheName, string listName, string value)
+    public async Task ListPushFrontAsync_NullChecksString_IsError(string cacheName, string listName, string value)
     {
         CacheListPushFrontResponse response = await client.ListPushFrontAsync(cacheName, listName, value, false);
         Assert.True(response is CacheListPushFrontResponse.Error);
@@ -170,16 +172,18 @@ public class ListTest : TestBase
     }
 
     [Fact]
-    public async Task ListPushFrontAsync_ValueIsStringTruncateBackToSizeIsZero_ThrowsException()
+    public async Task ListPushFrontAsync_ValueIsStringTruncateBackToSizeIsZero_IsError()
     {
-        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await client.ListPushFrontAsync("myCache", "listName", "value", false, truncateBackToSize: 0));
+        var response = await client.ListPushFrontAsync("myCache", "listName", "value", false, truncateBackToSize: 0);
+        Assert.True(response is CacheListPushFrontResponse.Error);
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListPushFrontResponse.Error)response).ErrorCode);
     }
 
     [Theory]
     [InlineData(null, "my-list", new byte[] { 0x00 })]
     [InlineData("cache", null, new byte[] { 0x00 })]
     [InlineData("cache", "my-list", null)]
-    public async Task ListPushBackAsync_NullChecksByteArray_ThrowsException(string cacheName, string listName, byte[] value)
+    public async Task ListPushBackAsync_NullChecksByteArray_IsError(string cacheName, string listName, byte[] value)
     {
         CacheListPushBackResponse response = await client.ListPushBackAsync(cacheName, listName, value, false);
         Assert.True(response is CacheListPushBackResponse.Error);
@@ -253,16 +257,18 @@ public class ListTest : TestBase
     }
 
     [Fact]
-    public async Task ListPushBackAsync_ValueIsByteArrayTruncateFrontToSizeIsZero_ThrowsException()
+    public async Task ListPushBackAsync_ValueIsByteArrayTruncateFrontToSizeIsZero_IsError()
     {
-        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await client.ListPushBackAsync("myCache", "listName", new byte[] { 0x00 }, false, truncateFrontToSize: 0));
+        var response = await client.ListPushBackAsync("myCache", "listName", new byte[] { 0x00 }, false, truncateFrontToSize: 0);
+        Assert.True(response is CacheListPushBackResponse.Error);
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListPushBackResponse.Error)response).ErrorCode);
     }
 
     [Theory]
     [InlineData(null, "my-list", "my-value")]
     [InlineData("cache", null, "my-value")]
     [InlineData("cache", "my-list", null)]
-    public async Task ListPushBackAsync_NullChecksString_ThrowsException(string cacheName, string listName, string value)
+    public async Task ListPushBackAsync_NullChecksString_IsError(string cacheName, string listName, string value)
     {
         CacheListPushBackResponse response = await client.ListPushBackAsync(cacheName, listName, value, false);
         Assert.True(response is CacheListPushBackResponse.Error);
@@ -408,15 +414,17 @@ public class ListTest : TestBase
     }
 
     [Fact]
-    public async Task ListPushBackAsync_ValueIsStringTruncateFrontToSizeIsZero_ThrowsException()
+    public async Task ListPushBackAsync_ValueIsStringTruncateFrontToSizeIsZero_IsError()
     {
-        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await client.ListPushBackAsync("myCache", "listName", "value", false, truncateFrontToSize: 0));
+        var response = await client.ListPushBackAsync("myCache", "listName", "value", false, truncateFrontToSize: 0);
+        Assert.True(response is CacheListPushBackResponse.Error);
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListPushBackResponse.Error)response).ErrorCode);
     }
 
     [Theory]
     [InlineData(null, "my-list")]
     [InlineData("cache", null)]
-    public async Task ListPopFrontAsync_NullChecks_ThrowsException(string cacheName, string listName)
+    public async Task ListPopFrontAsync_NullChecks_IsError(string cacheName, string listName)
     {
         CacheListPopFrontResponse response = await client.ListPopFrontAsync(cacheName, listName);
         Assert.True(response is CacheListPopFrontResponse.Error);
@@ -466,7 +474,7 @@ public class ListTest : TestBase
     [Theory]
     [InlineData(null, "my-list")]
     [InlineData("cache", null)]
-    public async Task ListPopBackAsync_NullChecks_ThrowsException(string cacheName, string listName)
+    public async Task ListPopBackAsync_NullChecks_IsError(string cacheName, string listName)
     {
         CacheListPopBackResponse response = await client.ListPopBackAsync(cacheName, listName);
         Assert.True(response is CacheListPopBackResponse.Error);
@@ -516,7 +524,7 @@ public class ListTest : TestBase
     [Theory]
     [InlineData(null, "my-list")]
     [InlineData("cache", null)]
-    public async Task ListFetchAsync_NullChecks_ThrowsException(string cacheName, string listName)
+    public async Task ListFetchAsync_NullChecks_IsError(string cacheName, string listName)
     {
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Error);
@@ -573,7 +581,7 @@ public class ListTest : TestBase
     [InlineData(null, "my-list", new byte[] { 0x00 })]
     [InlineData("cache", null, new byte[] { 0x00 })]
     [InlineData("cache", "my-list", null)]
-    public async Task ListRemoveValueAsync_NullChecksByteArray_ThrowsException(string cacheName, string listName, byte[] value)
+    public async Task ListRemoveValueAsync_NullChecksByteArray_IsError(string cacheName, string listName, byte[] value)
     {
         CacheListRemoveValueResponse response = await client.ListRemoveValueAsync(cacheName, listName, value);
         Assert.True(response is CacheListRemoveValueResponse.Error);
@@ -638,7 +646,7 @@ public class ListTest : TestBase
     [InlineData(null, "my-list", "")]
     [InlineData("cache", null, "")]
     [InlineData("cache", "my-list", null)]
-    public async Task ListRemoveValueAsync_NullChecksString_ThrowsException(string cacheName, string listName, string value)
+    public async Task ListRemoveValueAsync_NullChecksString_IsError(string cacheName, string listName, string value)
     {
         CacheListRemoveValueResponse response = await client.ListRemoveValueAsync(cacheName, listName, value);
         Assert.True(response is CacheListRemoveValueResponse.Error);
@@ -702,7 +710,7 @@ public class ListTest : TestBase
     [Theory]
     [InlineData(null, "my-list")]
     [InlineData("cache", null)]
-    public async Task ListLengthAsync_NullChecks_ThrowsException(string cacheName, string listName)
+    public async Task ListLengthAsync_NullChecks_IsError(string cacheName, string listName)
     {
         CacheListLengthResponse response = await client.ListLengthAsync(cacheName, listName);
         Assert.True(response is CacheListLengthResponse.Error);
@@ -736,7 +744,7 @@ public class ListTest : TestBase
     [Theory]
     [InlineData(null, "my-list")]
     [InlineData("my-cache", null)]
-    public async Task ListDeleteAsync_NullChecks_ThrowsException(string cacheName, string listName)
+    public async Task ListDeleteAsync_NullChecks_IsError(string cacheName, string listName)
     {
         var response = await client.ListDeleteAsync(cacheName, listName);
         Assert.True(response is CacheListDeleteResponse.Error);

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/SetTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/SetTest.cs
@@ -15,7 +15,7 @@ public class SetTest : TestBase
     [InlineData(null, "my-set", new byte[] { 0x00 })]
     [InlineData("cache", null, new byte[] { 0x00 })]
     [InlineData("cache", "my-set", null)]
-    public async Task SetAddAsync_NullChecksByteArray_ThrowsException(string cacheName, string setName, byte[] element)
+    public async Task SetAddAsync_NullChecksByteArray_IsError(string cacheName, string setName, byte[] element)
     {
         CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, false);
         Assert.True(response is CacheSetAddResponse.Error);
@@ -76,7 +76,7 @@ public class SetTest : TestBase
     [InlineData(null, "my-set", "my-element")]
     [InlineData("cache", null, "my-element")]
     [InlineData("cache", "my-set", null)]
-    public async Task SetAddAsync_NullChecksString_ThrowsException(string cacheName, string setName, string element)
+    public async Task SetAddAsync_NullChecksString_IsError(string cacheName, string setName, string element)
     {
         CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, false);
         Assert.True(response is CacheSetAddResponse.Error);
@@ -136,7 +136,7 @@ public class SetTest : TestBase
     }
 
     [Fact]
-    public async Task SetAddBatchAsync_NullChecksByteArray_ThrowsException()
+    public async Task SetAddBatchAsync_NullChecksByteArray_IsError()
     {
         var setName = Utils.NewGuidString();
         var set = new HashSet<byte[]>();
@@ -216,7 +216,7 @@ public class SetTest : TestBase
     }
 
     [Fact]
-    public async Task SetAddBatchAsync_NullChecksString_ThrowsException()
+    public async Task SetAddBatchAsync_NullChecksString_IsError()
     {
         var setName = Utils.NewGuidString();
         var set = new HashSet<string>();
@@ -300,7 +300,7 @@ public class SetTest : TestBase
     [InlineData(null, "my-set", new byte[] { 0x00 })]
     [InlineData("cache", null, new byte[] { 0x00 })]
     [InlineData("cache", "my-set", null)]
-    public async Task SetRemoveElementAsync_NullChecksByteArray_ThrowsException(string cacheName, string setName, byte[] element)
+    public async Task SetRemoveElementAsync_NullChecksByteArray_IsError(string cacheName, string setName, byte[] element)
     {
         CacheSetRemoveElementResponse response = await client.SetRemoveElementAsync(cacheName, setName, element);
         Assert.True(response is CacheSetRemoveElementResponse.Error);
@@ -354,7 +354,7 @@ public class SetTest : TestBase
     [InlineData(null, "my-set", "my-element")]
     [InlineData("cache", null, "my-element")]
     [InlineData("cache", "my-set", null)]
-    public async Task SetRemoveElementAsync_NullChecksString_ThrowsException(string cacheName, string setName, string element)
+    public async Task SetRemoveElementAsync_NullChecksString_IsError(string cacheName, string setName, string element)
     {
         CacheSetRemoveElementResponse response = await client.SetRemoveElementAsync(cacheName, setName, element);
         Assert.True(response is CacheSetRemoveElementResponse.Error);
@@ -404,7 +404,7 @@ public class SetTest : TestBase
     }
 
     [Fact]
-    public async Task SetRemoveElementsAsync_NullChecksElementsAreByteArray_ThrowsException()
+    public async Task SetRemoveElementsAsync_NullChecksElementsAreByteArray_IsError()
     {
         var setName = Utils.NewGuidString();
         var testData = new byte[][][] { new byte[][] { Utils.NewGuidByteArray(), Utils.NewGuidByteArray() }, new byte[][] { Utils.NewGuidByteArray(), null! } };
@@ -463,7 +463,7 @@ public class SetTest : TestBase
     }
 
     [Fact]
-    public async Task SetRemoveElementsAsync_NullChecksElementsAreString_ThrowsException()
+    public async Task SetRemoveElementsAsync_NullChecksElementsAreString_IsError()
     {
         var setName = Utils.NewGuidString();
         var testData = new string[][] { new string[] { Utils.NewGuidString(), Utils.NewGuidString() }, new string[] { Utils.NewGuidString(), null! } };
@@ -524,7 +524,7 @@ public class SetTest : TestBase
     [Theory]
     [InlineData(null, "my-set")]
     [InlineData("cache", null)]
-    public async Task SetFetchAsync_NullChecks_ThrowsException(string cacheName, string setName)
+    public async Task SetFetchAsync_NullChecks_IsError(string cacheName, string setName)
     {
         CacheSetFetchResponse response = await client.SetFetchAsync(cacheName, setName);
         Assert.True(response is CacheSetFetchResponse.Error);
@@ -570,7 +570,7 @@ public class SetTest : TestBase
     [Theory]
     [InlineData(null, "my-set")]
     [InlineData("my-cache", null)]
-    public async Task SetDeleteAsync_NullChecks_ThrowsException(string cacheName, string setName)
+    public async Task SetDeleteAsync_NullChecks_IsError(string cacheName, string setName)
     {
         CacheSetDeleteResponse response = await client.SetDeleteAsync(cacheName, setName);
         Assert.True(response is CacheSetDeleteResponse.Error);


### PR DESCRIPTION
In a few cases -- `DictionaryIncrementAsync` and `ListPush*`, there were exceptions not mapped to errors. This PR corrects that.

We also update the example for `DictionaryIncrementAsync` to reflect the latest response patterns.

Closes #32 