### PR TITLE
chore: improve error messages when type assertions fail in tests

### DIFF
--- a/tests/Integration/Momento.Sdk.Incubating.Tests/BatchTests.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/BatchTests.cs
@@ -16,14 +16,14 @@ public class BatchTests : TestBase
     public async Task GetBatchAsync_NullCheckByteArray_IsError()
     {
         CacheGetBatchResponse response = await client.GetBatchAsync(null!, new List<byte[]>());
-        Assert.True(response is CacheGetBatchResponse.Error);
+        Assert.True(response is CacheGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheGetBatchResponse.Error)response).ErrorCode);
         response = await client.GetBatchAsync("cache", (List<byte[]>)null!);
-        Assert.True(response is CacheGetBatchResponse.Error);
+        Assert.True(response is CacheGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheGetBatchResponse.Error)response).ErrorCode);
         var badList = new List<byte[]>(new byte[][] { Utils.NewGuidByteArray(), null! });
         response = await client.GetBatchAsync("cache", badList);
-        Assert.True(response is CacheGetBatchResponse.Error);
+        Assert.True(response is CacheGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheGetBatchResponse.Error)response).ErrorCode);
     }
 
@@ -35,14 +35,14 @@ public class BatchTests : TestBase
         string key2 = Utils.NewGuidString();
         string value2 = Utils.NewGuidString();
         var setResponse = await client.SetAsync(cacheName, key1, value1);
-        Assert.True(setResponse is CacheSetResponse.Success);
+        Assert.True(setResponse is CacheSetResponse.Success, $"Unexpected response: {setResponse}");
         setResponse = await client.SetAsync(cacheName, key2, value2);
-        Assert.True(setResponse is CacheSetResponse.Success);
+        Assert.True(setResponse is CacheSetResponse.Success, $"Unexpected response: {setResponse}");
 
         List<byte[]> keys = new() { Utils.Utf8ToByteArray(key1), Utils.Utf8ToByteArray(key2) };
 
         CacheGetBatchResponse result = await client.GetBatchAsync(cacheName, keys);
-        Assert.True(result is CacheGetBatchResponse.Success);
+        Assert.True(result is CacheGetBatchResponse.Success, $"Unexpected response: {result}");
         var goodResult = (CacheGetBatchResponse.Success)result;
         string? stringResult1 = goodResult.Strings().ToList()[0];
         string? stringResult2 = goodResult.Strings().ToList()[1];
@@ -54,15 +54,15 @@ public class BatchTests : TestBase
     public async Task GetBatchAsync_NullCheckString_IsError()
     {
         CacheGetBatchResponse response = await client.GetBatchAsync(null!, new List<string>());
-        Assert.True(response is CacheGetBatchResponse.Error);
+        Assert.True(response is CacheGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheGetBatchResponse.Error)response).ErrorCode);
         response = await client.GetBatchAsync("cache", (List<string>)null!);
-        Assert.True(response is CacheGetBatchResponse.Error);
+        Assert.True(response is CacheGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheGetBatchResponse.Error)response).ErrorCode);
 
         List<string> strings = new(new string[] { "key1", "key2", null! });
         response = await client.GetBatchAsync("cache", strings);
-        Assert.True(response is CacheGetBatchResponse.Error);
+        Assert.True(response is CacheGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheGetBatchResponse.Error)response).ErrorCode);
     }
 
@@ -74,13 +74,13 @@ public class BatchTests : TestBase
         string key2 = Utils.NewGuidString();
         string value2 = Utils.NewGuidString();
         var setResponse = await client.SetAsync(cacheName, key1, value1);
-        Assert.True(setResponse is CacheSetResponse.Success);
+        Assert.True(setResponse is CacheSetResponse.Success, $"Unexpected response: {setResponse}");
         setResponse = await client.SetAsync(cacheName, key2, value2);
-        Assert.True(setResponse is CacheSetResponse.Success);
+        Assert.True(setResponse is CacheSetResponse.Success, $"Unexpected response: {setResponse}");
 
         List<string> keys = new() { key1, key2, "key123123" };
         CacheGetBatchResponse result = await client.GetBatchAsync(cacheName, keys);
-        Assert.True(result is CacheGetBatchResponse.Success);
+        Assert.True(result is CacheGetBatchResponse.Success, $"Unexpected response: {result}");
         var goodResult = (CacheGetBatchResponse.Success)result;
         Assert.Equal(goodResult.Strings(), new string[] { value1, value2, null! });
         Assert.True(goodResult.Responses[0] is CacheGetResponse.Hit);
@@ -100,7 +100,7 @@ public class BatchTests : TestBase
         using SimpleCacheClient simpleCacheClient = SimpleCacheClientFactory.CreateClient(config, this.authProvider, defaultTtl);
         List<string> keys = new() { Utils.NewGuidString(), Utils.NewGuidString(), Utils.NewGuidString(), Utils.NewGuidString() };
         CacheGetBatchResponse response = await simpleCacheClient.GetBatchAsync(cacheName, keys);
-        Assert.True(response is CacheGetBatchResponse.Error);
+        Assert.True(response is CacheGetBatchResponse.Error, $"Unexpected response: {response}");
         var badResponse = (CacheGetBatchResponse.Error)response;
         Assert.Equal(MomentoErrorCode.TIMEOUT_ERROR, badResponse.ErrorCode);
     }
@@ -109,15 +109,15 @@ public class BatchTests : TestBase
     public async Task SetBatchAsync_NullCheckByteArray_IsError()
     {
         CacheSetBatchResponse response = await client.SetBatchAsync(null!, new Dictionary<byte[], byte[]>());
-        Assert.True(response is CacheSetBatchResponse.Error);
+        Assert.True(response is CacheSetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetBatchResponse.Error)response).ErrorCode);
         response = await client.SetBatchAsync("cache", (Dictionary<byte[], byte[]>)null!);
-        Assert.True(response is CacheSetBatchResponse.Error);
+        Assert.True(response is CacheSetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetBatchResponse.Error)response).ErrorCode);
 
         var badDictionary = new Dictionary<byte[], byte[]>() { { Utils.Utf8ToByteArray("asdf"), null! } };
         response = await client.SetBatchAsync("cache", badDictionary);
-        Assert.True(response is CacheSetBatchResponse.Error);
+        Assert.True(response is CacheSetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetBatchResponse.Error)response).ErrorCode);
     }
 
@@ -136,12 +136,12 @@ public class BatchTests : TestBase
         await client.SetBatchAsync(cacheName, dictionary);
 
         var getResponse = await client.GetAsync(cacheName, key1);
-        Assert.True(getResponse is CacheGetResponse.Hit);
+        Assert.True(getResponse is CacheGetResponse.Hit, $"Unexpected response: {getResponse}");
         var goodGetResponse = (CacheGetResponse.Hit)getResponse;
         Assert.Equal(value1, goodGetResponse.ValueByteArray);
 
         getResponse = await client.GetAsync(cacheName, key2);
-        Assert.True(getResponse is CacheGetResponse.Hit);
+        Assert.True(getResponse is CacheGetResponse.Hit, $"Unexpected response: {getResponse}");
         goodGetResponse = (CacheGetResponse.Hit)getResponse;
         Assert.Equal(value2, goodGetResponse.ValueByteArray);
     }
@@ -150,15 +150,15 @@ public class BatchTests : TestBase
     public async Task SetBatchAsync_NullCheckStrings_IsError()
     {
         CacheSetBatchResponse response = await client.SetBatchAsync(null!, new Dictionary<string, string>());
-        Assert.True(response is CacheSetBatchResponse.Error);
+        Assert.True(response is CacheSetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetBatchResponse.Error)response).ErrorCode);
         response = await client.SetBatchAsync("cache", (Dictionary<string, string>)null!);
-        Assert.True(response is CacheSetBatchResponse.Error);
+        Assert.True(response is CacheSetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetBatchResponse.Error)response).ErrorCode);
 
         var badDictionary = new Dictionary<string, string>() { { "asdf", null! } };
         response = await client.SetBatchAsync("cache", badDictionary);
-        Assert.True(response is CacheSetBatchResponse.Error);
+        Assert.True(response is CacheSetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetBatchResponse.Error)response).ErrorCode);
     }
 
@@ -177,12 +177,12 @@ public class BatchTests : TestBase
         await client.SetBatchAsync(cacheName, dictionary);
 
         var getResponse = await client.GetAsync(cacheName, key1);
-        Assert.True(getResponse is CacheGetResponse.Hit);
+        Assert.True(getResponse is CacheGetResponse.Hit, $"Unexpected response: {getResponse}");
         var goodGetResponse = (CacheGetResponse.Hit)getResponse;
         Assert.Equal(value1, goodGetResponse.ValueString);
 
         getResponse = await client.GetAsync(cacheName, key2);
-        Assert.True(getResponse is CacheGetResponse.Hit);
+        Assert.True(getResponse is CacheGetResponse.Hit, $"Unexpected response: {getResponse}");
         goodGetResponse = (CacheGetResponse.Hit)getResponse;
         Assert.Equal(value2, goodGetResponse.ValueString);
     }

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
@@ -18,7 +18,7 @@ public class DictionaryTest : TestBase
     public async Task DictionaryGetAsync_NullChecksFieldIsByteArray_IsError(string cacheName, string dictionaryName, byte[] field)
     {
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Error);
+        Assert.True(response is CacheDictionaryGetResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetResponse.Error)response).ErrorCode);
     }
 
@@ -30,7 +30,7 @@ public class DictionaryTest : TestBase
     public async Task DictionarySetAsync_NullChecksFieldIsByteArrayValueIsByteArray_IsError(string cacheName, string dictionaryName, byte[] field, byte[] value)
     {
         CacheDictionarySetResponse response = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false);
-        Assert.True(response is CacheDictionarySetResponse.Error);
+        Assert.True(response is CacheDictionarySetResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetResponse.Error)response).ErrorCode);
     }
 
@@ -40,7 +40,7 @@ public class DictionaryTest : TestBase
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidByteArray();
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Miss);
+        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public class DictionaryTest : TestBase
         await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false);
 
         CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(getResponse is CacheDictionaryGetResponse.Hit);
+        Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
     }
 
     [Fact]
@@ -64,11 +64,11 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
 
         CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false);
-        Assert.True(setResponse is CacheDictionarySetResponse.Success);
+        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
 
         var otherField = Utils.NewGuidByteArray();
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, otherField);
-        Assert.True(response is CacheDictionaryGetResponse.Miss);
+        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -79,15 +79,15 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
 
         CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttl: TimeSpan.FromSeconds(5));
-        Assert.True(setResponse is CacheDictionarySetResponse.Success);
+        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(100);
 
         setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttl: TimeSpan.FromSeconds(10));
-        Assert.True(setResponse is CacheDictionarySetResponse.Success);
+        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(4900);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Miss);
+        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -98,13 +98,13 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
 
         CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttl: TimeSpan.FromSeconds(2));
-        Assert.True(setResponse is CacheDictionarySetResponse.Success);
+        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, true, ttl: TimeSpan.FromSeconds(10));
-        Assert.True(setResponse is CacheDictionarySetResponse.Success);
+        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(2000);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Hit);
+        Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
         Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).ByteArray);
     }
 
@@ -115,7 +115,7 @@ public class DictionaryTest : TestBase
     public async Task DictionaryIncrementAsync_NullChecksFieldIsString_IsError(string cacheName, string dictionaryName, string field)
     {
         CacheDictionaryIncrementResponse response = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, refreshTtl: true);
-        Assert.True(response is CacheDictionaryIncrementResponse.Error);
+        Assert.True(response is CacheDictionaryIncrementResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryIncrementResponse.Error)response).ErrorCode);
     }
 
@@ -126,22 +126,22 @@ public class DictionaryTest : TestBase
         var fieldName = Utils.NewGuidString();
 
         CacheDictionaryIncrementResponse incrementResponse = await client.DictionaryIncrementAsync(cacheName, dictionaryName, fieldName, false, 1);
-        Assert.True(incrementResponse is CacheDictionaryIncrementResponse.Success);
+        Assert.True(incrementResponse is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {incrementResponse}");
         var successResponse = (CacheDictionaryIncrementResponse.Success)incrementResponse;
         Assert.Equal(1, successResponse.Value);
 
         incrementResponse = await client.DictionaryIncrementAsync(cacheName, dictionaryName, fieldName, false, 41);
-        Assert.True(incrementResponse is CacheDictionaryIncrementResponse.Success);
+        Assert.True(incrementResponse is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {incrementResponse}");
         successResponse = (CacheDictionaryIncrementResponse.Success)incrementResponse;
         Assert.Equal(42, successResponse.Value);
 
         incrementResponse = await client.DictionaryIncrementAsync(cacheName, dictionaryName, fieldName, false, -1042);
-        Assert.True(incrementResponse is CacheDictionaryIncrementResponse.Success);
+        Assert.True(incrementResponse is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {incrementResponse}");
         successResponse = (CacheDictionaryIncrementResponse.Success)incrementResponse;
         Assert.Equal(-1000, successResponse.Value);
 
         CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, fieldName);
-        Assert.True(getResponse is CacheDictionaryGetResponse.Hit);
+        Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
         var hitResponse = (CacheDictionaryGetResponse.Hit)getResponse;
         Assert.Equal("-1000", hitResponse.String());
     }
@@ -153,13 +153,13 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
 
         CacheDictionaryIncrementResponse resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, refreshTtl: false, ttl: TimeSpan.FromSeconds(2));
-        Assert.True(resp is CacheDictionaryIncrementResponse.Success);
+        Assert.True(resp is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {resp}");
         resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, refreshTtl: true, ttl: TimeSpan.FromSeconds(10));
-        Assert.True(resp is CacheDictionaryIncrementResponse.Success);
+        Assert.True(resp is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {resp}");
         await Task.Delay(2000);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Hit);
+        Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
         Assert.Equal("2", ((CacheDictionaryGetResponse.Hit)response).String());
     }
 
@@ -170,15 +170,15 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
 
         CacheDictionaryIncrementResponse resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, refreshTtl: false, ttl: TimeSpan.FromSeconds(5));
-        Assert.True(resp is CacheDictionaryIncrementResponse.Success);
+        Assert.True(resp is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {resp}");
         await Task.Delay(100);
 
         resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, refreshTtl: false, ttl: TimeSpan.FromSeconds(10));
-        Assert.True(resp is CacheDictionaryIncrementResponse.Success);
+        Assert.True(resp is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {resp}");
         await Task.Delay(4900);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Miss);
+        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -190,19 +190,19 @@ public class DictionaryTest : TestBase
         // Set field
         await client.DictionarySetAsync(cacheName, dictionaryName, field, "10", false);
         CacheDictionaryIncrementResponse incrementResponse = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, amount: 0, refreshTtl: false);
-        Assert.True(incrementResponse is CacheDictionaryIncrementResponse.Success);
+        Assert.True(incrementResponse is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {incrementResponse}");
         var successResponse = (CacheDictionaryIncrementResponse.Success)incrementResponse;
         Assert.Equal(10, successResponse.Value);
 
         incrementResponse = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, amount: 90, refreshTtl: false);
-        Assert.True(incrementResponse is CacheDictionaryIncrementResponse.Success);
+        Assert.True(incrementResponse is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {incrementResponse}");
         successResponse = (CacheDictionaryIncrementResponse.Success)incrementResponse;
         Assert.Equal(100, successResponse.Value);
 
         // Reset field
         await client.DictionarySetAsync(cacheName, dictionaryName, field, "0", false);
         incrementResponse = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, amount: 0, refreshTtl: false);
-        Assert.True(incrementResponse is CacheDictionaryIncrementResponse.Success);
+        Assert.True(incrementResponse is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {incrementResponse}");
         successResponse = (CacheDictionaryIncrementResponse.Success)incrementResponse;
         Assert.Equal(0, successResponse.Value);
     }
@@ -214,10 +214,10 @@ public class DictionaryTest : TestBase
         var fieldName = Utils.NewGuidString();
 
         var setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, fieldName, "abcxyz", false);
-        Assert.True(setResponse is CacheDictionarySetResponse.Success);
+        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
 
         var dictionaryIncrementResponse = await client.DictionaryIncrementAsync(cacheName, dictionaryName, fieldName, refreshTtl: false);
-        Assert.True(dictionaryIncrementResponse is CacheDictionaryIncrementResponse.Error);
+        Assert.True(dictionaryIncrementResponse is CacheDictionaryIncrementResponse.Error, $"Unexpected response: {dictionaryIncrementResponse}");
         Assert.Equal(MomentoErrorCode.FAILED_PRECONDITION_ERROR, ((CacheDictionaryIncrementResponse.Error)dictionaryIncrementResponse).ErrorCode);
     }
 
@@ -228,7 +228,7 @@ public class DictionaryTest : TestBase
     public async Task DictionaryGetAsync_NullChecksFieldIsString_IsError(string cacheName, string dictionaryName, string field)
     {
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Error);
+        Assert.True(response is CacheDictionaryGetResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetResponse.Error)response).ErrorCode);
     }
 
@@ -240,7 +240,7 @@ public class DictionaryTest : TestBase
     public async Task DictionarySetAsync_NullChecksFieldIsStringValueIsString_IsError(string cacheName, string dictionaryName, string field, string value)
     {
         CacheDictionarySetResponse response = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false);
-        Assert.True(response is CacheDictionarySetResponse.Error);
+        Assert.True(response is CacheDictionarySetResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetResponse.Error)response).ErrorCode);
     }
 
@@ -250,7 +250,7 @@ public class DictionaryTest : TestBase
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidString();
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Miss);
+        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -261,10 +261,10 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidString();
 
         CacheDictionarySetResponse response = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false);
-        Assert.True(response is CacheDictionarySetResponse.Success);
+        Assert.True(response is CacheDictionarySetResponse.Success, $"Unexpected response: {response}");
 
         CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(getResponse is CacheDictionaryGetResponse.Hit);
+        Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
     }
 
     [Fact]
@@ -275,11 +275,11 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidString();
 
         CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false);
-        Assert.True(setResponse is CacheDictionarySetResponse.Success);
+        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
 
         var otherField = Utils.NewGuidString();
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, otherField);
-        Assert.True(response is CacheDictionaryGetResponse.Miss);
+        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -290,15 +290,15 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidString();
 
         CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttl: TimeSpan.FromSeconds(5));
-        Assert.True(setResponse is CacheDictionarySetResponse.Success);
+        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(100);
 
         setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttl: TimeSpan.FromSeconds(10));
-        Assert.True(setResponse is CacheDictionarySetResponse.Success);
+        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(4900);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Miss);
+        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -309,13 +309,13 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidString();
 
         CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttl: TimeSpan.FromSeconds(2));
-        Assert.True(setResponse is CacheDictionarySetResponse.Success);
+        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, true, ttl: TimeSpan.FromSeconds(10));
-        Assert.True(setResponse is CacheDictionarySetResponse.Success);
+        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(2000);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Hit);
+        Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
         Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).String());
     }
 
@@ -327,7 +327,7 @@ public class DictionaryTest : TestBase
     public async Task DictionarySetAsync_NullChecksFieldIsStringValueIsByteArray_IsError(string cacheName, string dictionaryName, string field, byte[] value)
     {
         CacheDictionarySetResponse response = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false);
-        Assert.True(response is CacheDictionarySetResponse.Error);
+        Assert.True(response is CacheDictionarySetResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetResponse.Error)response).ErrorCode);
     }
 
@@ -339,10 +339,10 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
 
         CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false);
-        Assert.True(setResponse is CacheDictionarySetResponse.Success);
+        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
 
         CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(getResponse is CacheDictionaryGetResponse.Hit);
+        Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
     }
 
     [Fact]
@@ -353,15 +353,15 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
 
         CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttl: TimeSpan.FromSeconds(5));
-        Assert.True(setResponse is CacheDictionarySetResponse.Success);
+        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(100);
 
         setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttl: TimeSpan.FromSeconds(10));
-        Assert.True(setResponse is CacheDictionarySetResponse.Success);
+        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(4900);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Miss);
+        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -372,13 +372,13 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
 
         CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttl: TimeSpan.FromSeconds(2));
-        Assert.True(setResponse is CacheDictionarySetResponse.Success);
+        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, true, ttl: TimeSpan.FromSeconds(10));
-        Assert.True(setResponse is CacheDictionarySetResponse.Success);
+        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(2000);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Hit);
+        Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
         Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).ByteArray);
     }
 
@@ -388,18 +388,18 @@ public class DictionaryTest : TestBase
         var dictionaryName = Utils.NewGuidString();
         var dictionary = new Dictionary<byte[], byte[]>();
         CacheDictionarySetBatchResponse response = await client.DictionarySetBatchAsync(null!, dictionaryName, dictionary, false);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error);
+        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
         response = await client.DictionarySetBatchAsync(cacheName, null!, dictionary, false);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error);
+        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
         response = await client.DictionarySetBatchAsync(cacheName, dictionaryName, (IEnumerable<KeyValuePair<byte[], byte[]>>)null!, false);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error);
+        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
 
         dictionary[Utils.NewGuidByteArray()] = null!;
         response = await client.DictionarySetBatchAsync(cacheName, dictionaryName, dictionary, false);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error);
+        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
     }
 
@@ -417,11 +417,11 @@ public class DictionaryTest : TestBase
         await client.DictionarySetBatchAsync(cacheName, dictionaryName, items, false, TimeSpan.FromSeconds(10));
 
         CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field1);
-        Assert.True(getResponse is CacheDictionaryGetResponse.Hit);
+        Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
         Assert.Equal(value1, ((CacheDictionaryGetResponse.Hit)getResponse).ByteArray);
 
         getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field2);
-        Assert.True(getResponse is CacheDictionaryGetResponse.Hit);
+        Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
         Assert.Equal(value2, ((CacheDictionaryGetResponse.Hit)getResponse).ByteArray);
     }
 
@@ -440,7 +440,7 @@ public class DictionaryTest : TestBase
         await Task.Delay(4900);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Miss);
+        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -456,7 +456,7 @@ public class DictionaryTest : TestBase
         await Task.Delay(2000);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Hit);
+        Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
         Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).ByteArray);
     }
 
@@ -466,18 +466,18 @@ public class DictionaryTest : TestBase
         var dictionaryName = Utils.NewGuidString();
         var dictionary = new Dictionary<string, string>();
         CacheDictionarySetBatchResponse response = await client.DictionarySetBatchAsync(null!, dictionaryName, dictionary, false);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error);
+        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
         response = await client.DictionarySetBatchAsync(cacheName, null!, dictionary, false);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error);
+        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
         response = await client.DictionarySetBatchAsync(cacheName, dictionaryName, (IEnumerable<KeyValuePair<string, string>>)null!, false);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error);
+        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
 
         dictionary[Utils.NewGuidString()] = null!;
         response = await client.DictionarySetBatchAsync(cacheName, dictionaryName, dictionary, false);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error);
+        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
     }
 
@@ -495,11 +495,11 @@ public class DictionaryTest : TestBase
         await client.DictionarySetBatchAsync(cacheName, dictionaryName, items, false, TimeSpan.FromSeconds(10));
 
         CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field1);
-        Assert.True(getResponse is CacheDictionaryGetResponse.Hit);
+        Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
         Assert.Equal(value1, ((CacheDictionaryGetResponse.Hit)getResponse).String());
 
         getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field2);
-        Assert.True(getResponse is CacheDictionaryGetResponse.Hit);
+        Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
         Assert.Equal(value2, ((CacheDictionaryGetResponse.Hit)getResponse).String());
     }
 
@@ -518,7 +518,7 @@ public class DictionaryTest : TestBase
         await Task.Delay(4900);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Miss);
+        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -534,7 +534,7 @@ public class DictionaryTest : TestBase
         await Task.Delay(2000);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Hit);
+        Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
         Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).String());
     }
 
@@ -544,18 +544,18 @@ public class DictionaryTest : TestBase
         var dictionaryName = Utils.NewGuidString();
         var dictionary = new Dictionary<string, string>();
         CacheDictionarySetBatchResponse response = await client.DictionarySetBatchAsync(null!, dictionaryName, dictionary, false);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error);
+        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
         response = await client.DictionarySetBatchAsync(cacheName, null!, dictionary, false);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error);
+        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
         response = await client.DictionarySetBatchAsync(cacheName, dictionaryName, (IEnumerable<KeyValuePair<string, byte[]>>)null!, false);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error);
+        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
 
         dictionary[Utils.NewGuidString()] = null!;
         response = await client.DictionarySetBatchAsync(cacheName, dictionaryName, dictionary, false);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error);
+        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
     }
 
@@ -573,11 +573,11 @@ public class DictionaryTest : TestBase
         await client.DictionarySetBatchAsync(cacheName, dictionaryName, items, false, TimeSpan.FromSeconds(10));
 
         CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field1);
-        Assert.True(getResponse is CacheDictionaryGetResponse.Hit);
+        Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
         Assert.Equal(value1, ((CacheDictionaryGetResponse.Hit)getResponse).ByteArray);
 
         getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field2);
-        Assert.True(getResponse is CacheDictionaryGetResponse.Hit);
+        Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
         Assert.Equal(value2, ((CacheDictionaryGetResponse.Hit)getResponse).ByteArray);
     }
 
@@ -596,7 +596,7 @@ public class DictionaryTest : TestBase
         await Task.Delay(4900);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Miss);
+        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -612,7 +612,7 @@ public class DictionaryTest : TestBase
         await Task.Delay(2000);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Hit);
+        Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
         Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).ByteArray);
     }
 
@@ -623,30 +623,30 @@ public class DictionaryTest : TestBase
         var testData = new byte[][][] { new byte[][] { Utils.NewGuidByteArray(), Utils.NewGuidByteArray() }, new byte[][] { Utils.NewGuidByteArray(), null! } };
 
         CacheDictionaryGetBatchResponse response = await client.DictionaryGetBatchAsync(null!, dictionaryName, testData[0]);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error);
+        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
         response = await client.DictionaryGetBatchAsync(cacheName, null!, testData[0]);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error);
+        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
         response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, (byte[][])null!);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error);
+        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
         response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, testData[1]);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error);
+        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
 
         var fieldsList = new List<byte[]>(testData[0]);
         response = await client.DictionaryGetBatchAsync(null!, dictionaryName, fieldsList);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error);
+        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
         response = await client.DictionaryGetBatchAsync(cacheName, null!, fieldsList);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error);
+        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
         response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, (List<byte[]>)null!);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error);
+        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
         response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, new List<byte[]>(testData[1]));
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error);
+        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
     }
 
@@ -664,7 +664,7 @@ public class DictionaryTest : TestBase
         await client.DictionarySetAsync(cacheName, dictionaryName, field2, value2, false, TimeSpan.FromSeconds(10));
 
         CacheDictionaryGetBatchResponse response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, new byte[][] { field1, field2, field3 });
-        Assert.True(response is CacheDictionaryGetBatchResponse.Success);
+        Assert.True(response is CacheDictionaryGetBatchResponse.Success, $"Unexpected response: {response}");
 
         var values = new byte[]?[] { value1, value2, null };
         Assert.Equal(values, ((CacheDictionaryGetBatchResponse.Success)response).ByteArrays);
@@ -679,7 +679,7 @@ public class DictionaryTest : TestBase
         var field3 = Utils.NewGuidByteArray();
 
         CacheDictionaryGetBatchResponse response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, new byte[][] { field1, field2, field3 });
-        Assert.True(response is CacheDictionaryGetBatchResponse.Success);
+        Assert.True(response is CacheDictionaryGetBatchResponse.Success, $"Unexpected response: {response}");
         var nullResponse = (CacheDictionaryGetBatchResponse.Success)response;
         var byteArrays = new byte[]?[] { null, null, null };
         var strings = new string?[] { null, null, null };
@@ -694,30 +694,30 @@ public class DictionaryTest : TestBase
         var dictionaryName = Utils.NewGuidString();
         var testData = new string[][] { new string[] { Utils.NewGuidString(), Utils.NewGuidString() }, new string[] { Utils.NewGuidString(), null! } };
         CacheDictionaryGetBatchResponse response = await client.DictionaryGetBatchAsync(null!, dictionaryName, testData[0]);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error);
+        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
         response = await client.DictionaryGetBatchAsync(cacheName, null!, testData[0]);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error);
+        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
         response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, (string[])null!);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error);
+        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
         response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, testData[1]);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error);
+        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
 
         var fieldsList = new List<string>(testData[0]);
         response = await client.DictionaryGetBatchAsync(null!, dictionaryName, fieldsList);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error);
+        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
         response = await client.DictionaryGetBatchAsync(cacheName, null!, fieldsList);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error);
+        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
         response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, (List<string>)null!);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error);
+        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
         response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, new List<string>(testData[1]));
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error);
+        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
     }
 
@@ -735,7 +735,7 @@ public class DictionaryTest : TestBase
         await client.DictionarySetAsync(cacheName, dictionaryName, field2, value2, false, TimeSpan.FromSeconds(10));
 
         CacheDictionaryGetBatchResponse response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, new string[] { field1, field2, field3 });
-        Assert.True(response is CacheDictionaryGetBatchResponse.Success);
+        Assert.True(response is CacheDictionaryGetBatchResponse.Success, $"Unexpected response: {response}");
         var values = new string?[] { value1, value2, null };
         Assert.Equal(values, ((CacheDictionaryGetBatchResponse.Success)response).Strings());
     }
@@ -746,7 +746,7 @@ public class DictionaryTest : TestBase
     public async Task DictionaryFetchAsync_NullChecks_IsError(string cacheName, string dictionaryName)
     {
         CacheDictionaryFetchResponse response = await client.DictionaryFetchAsync(cacheName, dictionaryName);
-        Assert.True(response is CacheDictionaryFetchResponse.Error);
+        Assert.True(response is CacheDictionaryFetchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryFetchResponse.Error)response).ErrorCode);
     }
 
@@ -755,7 +755,7 @@ public class DictionaryTest : TestBase
     {
         var dictionaryName = Utils.NewGuidString();
         CacheDictionaryFetchResponse response = await client.DictionaryFetchAsync(cacheName, dictionaryName);
-        Assert.True(response is CacheDictionaryFetchResponse.Miss);
+        Assert.True(response is CacheDictionaryFetchResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -776,7 +776,7 @@ public class DictionaryTest : TestBase
 
         CacheDictionaryFetchResponse fetchResponse = await client.DictionaryFetchAsync(cacheName, dictionaryName);
 
-        Assert.True(fetchResponse is CacheDictionaryFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheDictionaryFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheDictionaryFetchResponse.Hit)fetchResponse;
         Assert.Equal(hitResponse.StringStringDictionary(), contentDictionary);
 
@@ -802,7 +802,7 @@ public class DictionaryTest : TestBase
 
         CacheDictionaryFetchResponse fetchResponse = await client.DictionaryFetchAsync(cacheName, dictionaryName);
 
-        Assert.True(fetchResponse is CacheDictionaryFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheDictionaryFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheDictionaryFetchResponse.Hit)fetchResponse;
         Assert.Equal(hitResponse.StringByteArrayDictionary(), contentDictionary);
 
@@ -828,7 +828,7 @@ public class DictionaryTest : TestBase
 
         CacheDictionaryFetchResponse fetchResponse = await client.DictionaryFetchAsync(cacheName, dictionaryName);
 
-        Assert.True(fetchResponse is CacheDictionaryFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheDictionaryFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
 
         var hitResponse = (CacheDictionaryFetchResponse.Hit)fetchResponse;
         // Exercise byte array dictionary structural equality comparer
@@ -849,7 +849,7 @@ public class DictionaryTest : TestBase
     public async Task DictionaryDeleteAsync_NullChecks_IsError(string cacheName, string dictionaryName)
     {
         CacheDictionaryDeleteResponse response = await client.DictionaryDeleteAsync(cacheName, dictionaryName);
-        Assert.True(response is CacheDictionaryDeleteResponse.Error);
+        Assert.True(response is CacheDictionaryDeleteResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryDeleteResponse.Error)response).ErrorCode);
     }
 
@@ -892,7 +892,7 @@ public class DictionaryTest : TestBase
     public async Task DictionaryRemoveFieldAsync_NullChecksFieldIsString_IsError(string cacheName, string dictionaryName, string field)
     {
         CacheDictionaryRemoveFieldResponse response = await client.DictionaryRemoveFieldAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryRemoveFieldResponse.Error);
+        Assert.True(response is CacheDictionaryRemoveFieldResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryRemoveFieldResponse.Error)response).ErrorCode);
     }
 
@@ -947,30 +947,30 @@ public class DictionaryTest : TestBase
         var testData = new byte[][][] { new byte[][] { Utils.NewGuidByteArray(), Utils.NewGuidByteArray() }, new byte[][] { Utils.NewGuidByteArray(), null! } };
 
         CacheDictionaryRemoveFieldsResponse response = await client.DictionaryRemoveFieldsAsync(null!, dictionaryName, testData[0]);
-        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error);
+        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryRemoveFieldsResponse.Error)response).ErrorCode);
         response = await client.DictionaryRemoveFieldsAsync(cacheName, null!, testData[0]);
-        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error);
+        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryRemoveFieldsResponse.Error)response).ErrorCode);
         response = await client.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, (byte[][])null!);
-        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error);
+        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryRemoveFieldsResponse.Error)response).ErrorCode);
         response = await client.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, testData[1]);
-        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error);
+        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryRemoveFieldsResponse.Error)response).ErrorCode);
 
         var fieldsList = new List<byte[]>(testData[0]);
         response = await client.DictionaryRemoveFieldsAsync(null!, dictionaryName, fieldsList);
-        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error);
+        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryRemoveFieldsResponse.Error)response).ErrorCode);
         response = await client.DictionaryRemoveFieldsAsync(cacheName, null!, fieldsList);
-        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error);
+        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryRemoveFieldsResponse.Error)response).ErrorCode);
         response = await client.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, (List<byte[]>)null!);
-        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error);
+        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryRemoveFieldsResponse.Error)response).ErrorCode);
         response = await client.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, new List<byte[]>(testData[1]));
-        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error);
+        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryRemoveFieldsResponse.Error)response).ErrorCode);
     }
 
@@ -999,30 +999,30 @@ public class DictionaryTest : TestBase
         var dictionaryName = Utils.NewGuidString();
         var testData = new string[][] { new string[] { Utils.NewGuidString(), Utils.NewGuidString() }, new string[] { Utils.NewGuidString(), null! } };
         CacheDictionaryRemoveFieldsResponse response = await client.DictionaryRemoveFieldsAsync(null!, dictionaryName, testData[0]);
-        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error);
+        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryRemoveFieldsResponse.Error)response).ErrorCode);
         response = await client.DictionaryRemoveFieldsAsync(cacheName, null!, testData[0]);
-        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error);
+        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryRemoveFieldsResponse.Error)response).ErrorCode);
         response = await client.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, (string[])null!);
-        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error);
+        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryRemoveFieldsResponse.Error)response).ErrorCode);
         response = await client.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, testData[1]);
-        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error);
+        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryRemoveFieldsResponse.Error)response).ErrorCode);
 
         var fieldsList = new List<string>(testData[0]);
         response = await client.DictionaryRemoveFieldsAsync(null!, dictionaryName, fieldsList);
-        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error);
+        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryRemoveFieldsResponse.Error)response).ErrorCode);
         response = await client.DictionaryRemoveFieldsAsync(cacheName, null!, fieldsList);
-        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error);
+        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryRemoveFieldsResponse.Error)response).ErrorCode);
         response = await client.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, (List<string>)null!);
-        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error);
+        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryRemoveFieldsResponse.Error)response).ErrorCode);
         response = await client.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, new List<string>(testData[1]));
-        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error);
+        Assert.True(response is CacheDictionaryRemoveFieldsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryRemoveFieldsResponse.Error)response).ErrorCode);
     }
 

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
@@ -17,7 +17,7 @@ public class ListTest : TestBase
     public async Task ListPushFrontAsync_NullChecksByteArray_IsError(string cacheName, string listName, byte[] value)
     {
         CacheListPushFrontResponse response = await client.ListPushFrontAsync(cacheName, listName, value, false);
-        Assert.True(response is CacheListPushFrontResponse.Error);
+        Assert.True(response is CacheListPushFrontResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListPushFrontResponse.Error)response).ErrorCode);
     }
 
@@ -28,11 +28,11 @@ public class ListTest : TestBase
         var value1 = Utils.NewGuidByteArray();
 
         CacheListPushFrontResponse pushResponse = await client.ListPushFrontAsync(cacheName, listName, value1, false);
-        Assert.True(pushResponse is CacheListPushFrontResponse.Success);
+        Assert.True(pushResponse is CacheListPushFrontResponse.Success, $"Unexpected response: {pushResponse}");
         Assert.Equal(1, ((CacheListPushFrontResponse.Success)pushResponse).ListLength);
 
         CacheListFetchResponse fetchResponse = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(fetchResponse is CacheListFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
 
         var list = hitResponse.ByteArrayList;
@@ -42,12 +42,12 @@ public class ListTest : TestBase
         // Test push semantics
         var value2 = Utils.NewGuidByteArray();
         pushResponse = await client.ListPushFrontAsync(cacheName, listName, value2, false);
-        Assert.True(pushResponse is CacheListPushFrontResponse.Success);
+        Assert.True(pushResponse is CacheListPushFrontResponse.Success, $"Unexpected response: {pushResponse}");
         var successResponse = (CacheListPushFrontResponse.Success)pushResponse;
         Assert.Equal(2, successResponse.ListLength);
 
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(fetchResponse is CacheListFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
         list = hitResponse.ByteArrayList!;
         Assert.Equal(value2, list[0]);
@@ -67,7 +67,7 @@ public class ListTest : TestBase
         await Task.Delay(4900);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(response is CacheListFetchResponse.Miss);
+        Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -81,7 +81,7 @@ public class ListTest : TestBase
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(response is CacheListFetchResponse.Hit);
+        Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
         Assert.Equal(2, hitResponse.ByteArrayList!.Count);
     }
@@ -90,7 +90,7 @@ public class ListTest : TestBase
     public async Task ListPushFrontAsync_ValueIsByteArrayTruncateBackToSizeIsZero_IsError()
     {
         var response = await client.ListPushFrontAsync("myCache", "listName", new byte[] { 0x00 }, false, truncateBackToSize: 0);
-        Assert.True(response is CacheListPushFrontResponse.Error);
+        Assert.True(response is CacheListPushFrontResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListPushFrontResponse.Error)response).ErrorCode);
     }
 
@@ -101,7 +101,7 @@ public class ListTest : TestBase
     public async Task ListPushFrontAsync_NullChecksString_IsError(string cacheName, string listName, string value)
     {
         CacheListPushFrontResponse response = await client.ListPushFrontAsync(cacheName, listName, value, false);
-        Assert.True(response is CacheListPushFrontResponse.Error);
+        Assert.True(response is CacheListPushFrontResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListPushFrontResponse.Error)response).ErrorCode);
     }
 
@@ -112,12 +112,12 @@ public class ListTest : TestBase
         var value1 = Utils.NewGuidString();
 
         CacheListPushFrontResponse pushResponse = await client.ListPushFrontAsync(cacheName, listName, value1, false);
-        Assert.True(pushResponse is CacheListPushFrontResponse.Success);
+        Assert.True(pushResponse is CacheListPushFrontResponse.Success, $"Unexpected response: {pushResponse}");
         var successResponse = (CacheListPushFrontResponse.Success)pushResponse;
         Assert.Equal(1, successResponse.ListLength);
 
         CacheListFetchResponse fetchResponse = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(fetchResponse is CacheListFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
 
         var list = hitResponse.StringList();
@@ -127,12 +127,12 @@ public class ListTest : TestBase
         // Test push semantics
         var value2 = Utils.NewGuidString();
         pushResponse = await client.ListPushFrontAsync(cacheName, listName, value2, false);
-        Assert.True(pushResponse is CacheListPushFrontResponse.Success);
+        Assert.True(pushResponse is CacheListPushFrontResponse.Success, $"Unexpected response: {pushResponse}");
         successResponse = (CacheListPushFrontResponse.Success)pushResponse;
         Assert.Equal(2, successResponse.ListLength);
 
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(fetchResponse is CacheListFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
         list = hitResponse.StringList()!;
         Assert.Equal(value2, list[0]);
@@ -152,7 +152,7 @@ public class ListTest : TestBase
         await Task.Delay(4900);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(response is CacheListFetchResponse.Miss);
+        Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -166,7 +166,7 @@ public class ListTest : TestBase
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(response is CacheListFetchResponse.Hit);
+        Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
         Assert.Equal(2, hitResponse.StringList()!.Count);
     }
@@ -175,7 +175,7 @@ public class ListTest : TestBase
     public async Task ListPushFrontAsync_ValueIsStringTruncateBackToSizeIsZero_IsError()
     {
         var response = await client.ListPushFrontAsync("myCache", "listName", "value", false, truncateBackToSize: 0);
-        Assert.True(response is CacheListPushFrontResponse.Error);
+        Assert.True(response is CacheListPushFrontResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListPushFrontResponse.Error)response).ErrorCode);
     }
 
@@ -186,7 +186,7 @@ public class ListTest : TestBase
     public async Task ListPushBackAsync_NullChecksByteArray_IsError(string cacheName, string listName, byte[] value)
     {
         CacheListPushBackResponse response = await client.ListPushBackAsync(cacheName, listName, value, false);
-        Assert.True(response is CacheListPushBackResponse.Error);
+        Assert.True(response is CacheListPushBackResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListPushBackResponse.Error)response).ErrorCode);
     }
 
@@ -197,12 +197,12 @@ public class ListTest : TestBase
         var value1 = Utils.NewGuidByteArray();
 
         CacheListPushBackResponse pushResponse = await client.ListPushBackAsync(cacheName, listName, value1, false);
-        Assert.True(pushResponse is CacheListPushBackResponse.Success);
+        Assert.True(pushResponse is CacheListPushBackResponse.Success, $"Unexpected response: {pushResponse}");
         var successResponse = (CacheListPushBackResponse.Success)pushResponse;
         Assert.Equal(1, successResponse.ListLength);
 
         CacheListFetchResponse fetchResponse = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(fetchResponse is CacheListFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
 
         var list = hitResponse.ByteArrayList;
@@ -212,12 +212,12 @@ public class ListTest : TestBase
         // Test push semantics
         var value2 = Utils.NewGuidByteArray();
         pushResponse = await client.ListPushBackAsync(cacheName, listName, value2, false);
-        Assert.True(pushResponse is CacheListPushBackResponse.Success);
+        Assert.True(pushResponse is CacheListPushBackResponse.Success, $"Unexpected response: {pushResponse}");
         successResponse = (CacheListPushBackResponse.Success)pushResponse;
         Assert.Equal(2, successResponse.ListLength);
 
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(fetchResponse is CacheListFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
         list = hitResponse.ByteArrayList!;
         Assert.Equal(value1, list[0]);
@@ -237,7 +237,7 @@ public class ListTest : TestBase
         await Task.Delay(4900);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(response is CacheListFetchResponse.Miss);
+        Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -251,7 +251,7 @@ public class ListTest : TestBase
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(response is CacheListFetchResponse.Hit);
+        Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
         Assert.Equal(2, hitResponse.ByteArrayList!.Count);
     }
@@ -260,7 +260,7 @@ public class ListTest : TestBase
     public async Task ListPushBackAsync_ValueIsByteArrayTruncateFrontToSizeIsZero_IsError()
     {
         var response = await client.ListPushBackAsync("myCache", "listName", new byte[] { 0x00 }, false, truncateFrontToSize: 0);
-        Assert.True(response is CacheListPushBackResponse.Error);
+        Assert.True(response is CacheListPushBackResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListPushBackResponse.Error)response).ErrorCode);
     }
 
@@ -271,7 +271,7 @@ public class ListTest : TestBase
     public async Task ListPushBackAsync_NullChecksString_IsError(string cacheName, string listName, string value)
     {
         CacheListPushBackResponse response = await client.ListPushBackAsync(cacheName, listName, value, false);
-        Assert.True(response is CacheListPushBackResponse.Error);
+        Assert.True(response is CacheListPushBackResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListPushBackResponse.Error)response).ErrorCode);
     }
 
@@ -286,7 +286,7 @@ public class ListTest : TestBase
         await client.ListPushBackAsync(cacheName, listName, value2, false);
         await client.ListPushBackAsync(cacheName, listName, value3, false, null, 2);
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(response is CacheListFetchResponse.Hit);
+        Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
         Assert.Equal(2, hitResponse.StringList()!.Count);
         Assert.Equal(value2, hitResponse.StringList()![0]);
@@ -304,7 +304,7 @@ public class ListTest : TestBase
         await client.ListPushBackAsync(cacheName, listName, value2, false);
         await client.ListPushBackAsync(cacheName, listName, value3, false, null, 2);
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(response is CacheListFetchResponse.Hit);
+        Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
         Assert.Equal(2, hitResponse.ByteArrayList!.Count);
         Assert.Equal(value2, hitResponse.ByteArrayList![0]);
@@ -322,7 +322,7 @@ public class ListTest : TestBase
         await client.ListPushFrontAsync(cacheName, listName, value2, false);
         await client.ListPushFrontAsync(cacheName, listName, value3, false, null, 2);
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(response is CacheListFetchResponse.Hit);
+        Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
         Assert.Equal(2, hitResponse.StringList()!.Count);
         Assert.Equal(value2, hitResponse.StringList()![1]);
@@ -340,7 +340,7 @@ public class ListTest : TestBase
         await client.ListPushFrontAsync(cacheName, listName, value2, false);
         await client.ListPushFrontAsync(cacheName, listName, value3, false, null, 2);
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(response is CacheListFetchResponse.Hit);
+        Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
         Assert.Equal(2, hitResponse.ByteArrayList!.Count);
         Assert.Equal(value2, hitResponse.ByteArrayList![1]);
@@ -354,12 +354,12 @@ public class ListTest : TestBase
         var value1 = Utils.NewGuidString();
 
         CacheListPushBackResponse pushResponse = await client.ListPushBackAsync(cacheName, listName, value1, false);
-        Assert.True(pushResponse is CacheListPushBackResponse.Success);
+        Assert.True(pushResponse is CacheListPushBackResponse.Success, $"Unexpected response: {pushResponse}");
         var successResponse = (CacheListPushBackResponse.Success)pushResponse;
         Assert.Equal(1, successResponse.ListLength);
 
         CacheListFetchResponse fetchResponse = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(fetchResponse is CacheListFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
 
         var list = hitResponse.StringList();
@@ -374,7 +374,7 @@ public class ListTest : TestBase
         Assert.Equal(2, successResponse.ListLength);
 
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(fetchResponse is CacheListFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
         list = hitResponse.StringList()!;
         Assert.Equal(value1, list[0]);
@@ -394,7 +394,7 @@ public class ListTest : TestBase
         await Task.Delay(4900);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(response is CacheListFetchResponse.Miss);
+        Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -408,7 +408,7 @@ public class ListTest : TestBase
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(response is CacheListFetchResponse.Hit);
+        Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
         Assert.Equal(2, hitResponse.StringList()!.Count);
     }
@@ -417,7 +417,7 @@ public class ListTest : TestBase
     public async Task ListPushBackAsync_ValueIsStringTruncateFrontToSizeIsZero_IsError()
     {
         var response = await client.ListPushBackAsync("myCache", "listName", "value", false, truncateFrontToSize: 0);
-        Assert.True(response is CacheListPushBackResponse.Error);
+        Assert.True(response is CacheListPushBackResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListPushBackResponse.Error)response).ErrorCode);
     }
 
@@ -427,7 +427,7 @@ public class ListTest : TestBase
     public async Task ListPopFrontAsync_NullChecks_IsError(string cacheName, string listName)
     {
         CacheListPopFrontResponse response = await client.ListPopFrontAsync(cacheName, listName);
-        Assert.True(response is CacheListPopFrontResponse.Error);
+        Assert.True(response is CacheListPopFrontResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListPopFrontResponse.Error)response).ErrorCode);
     }
 
@@ -436,7 +436,7 @@ public class ListTest : TestBase
     {
         var listName = Utils.NewGuidString();
         CacheListPopFrontResponse response = await client.ListPopFrontAsync(cacheName, listName);
-        Assert.True(response is CacheListPopFrontResponse.Miss);
+        Assert.True(response is CacheListPopFrontResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -449,7 +449,7 @@ public class ListTest : TestBase
         await client.ListPushFrontAsync(cacheName, listName, value1, false);
         await client.ListPushFrontAsync(cacheName, listName, value2, false);
         CacheListPopFrontResponse response = await client.ListPopFrontAsync(cacheName, listName);
-        Assert.True(response is CacheListPopFrontResponse.Hit);
+        Assert.True(response is CacheListPopFrontResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListPopFrontResponse.Hit)response;
 
         Assert.Equal(value2, hitResponse.ByteArray);
@@ -465,7 +465,7 @@ public class ListTest : TestBase
         await client.ListPushFrontAsync(cacheName, listName, value1, false);
         await client.ListPushFrontAsync(cacheName, listName, value2, false);
         CacheListPopFrontResponse response = await client.ListPopFrontAsync(cacheName, listName);
-        Assert.True(response is CacheListPopFrontResponse.Hit);
+        Assert.True(response is CacheListPopFrontResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListPopFrontResponse.Hit)response;
 
         Assert.Equal(value2, hitResponse.String());
@@ -477,7 +477,7 @@ public class ListTest : TestBase
     public async Task ListPopBackAsync_NullChecks_IsError(string cacheName, string listName)
     {
         CacheListPopBackResponse response = await client.ListPopBackAsync(cacheName, listName);
-        Assert.True(response is CacheListPopBackResponse.Error);
+        Assert.True(response is CacheListPopBackResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListPopBackResponse.Error)response).ErrorCode);
     }
 
@@ -486,7 +486,7 @@ public class ListTest : TestBase
     {
         var listName = Utils.NewGuidString();
         CacheListPopBackResponse response = await client.ListPopBackAsync(cacheName, listName);
-        Assert.True(response is CacheListPopBackResponse.Miss);
+        Assert.True(response is CacheListPopBackResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -499,7 +499,7 @@ public class ListTest : TestBase
         await client.ListPushBackAsync(cacheName, listName, value1, false);
         await client.ListPushBackAsync(cacheName, listName, value2, false);
         CacheListPopBackResponse response = await client.ListPopBackAsync(cacheName, listName);
-        Assert.True(response is CacheListPopBackResponse.Hit);
+        Assert.True(response is CacheListPopBackResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListPopBackResponse.Hit)response;
 
         Assert.Equal(value2, hitResponse.ByteArray);
@@ -515,7 +515,7 @@ public class ListTest : TestBase
         await client.ListPushBackAsync(cacheName, listName, value1, false);
         await client.ListPushBackAsync(cacheName, listName, value2, false);
         CacheListPopBackResponse response = await client.ListPopBackAsync(cacheName, listName);
-        Assert.True(response is CacheListPopBackResponse.Hit);
+        Assert.True(response is CacheListPopBackResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListPopBackResponse.Hit)response;
 
         Assert.Equal(value2, hitResponse.String());
@@ -527,7 +527,7 @@ public class ListTest : TestBase
     public async Task ListFetchAsync_NullChecks_IsError(string cacheName, string listName)
     {
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(response is CacheListFetchResponse.Error);
+        Assert.True(response is CacheListFetchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListFetchResponse.Error)response).ErrorCode);
     }
 
@@ -536,7 +536,7 @@ public class ListTest : TestBase
     {
         var listName = Utils.NewGuidString();
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(response is CacheListFetchResponse.Miss);
+        Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -551,7 +551,7 @@ public class ListTest : TestBase
         await client.ListPushFrontAsync(cacheName, listName, field1, true, ttl: TimeSpan.FromSeconds(10));
 
         CacheListFetchResponse fetchResponse = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(fetchResponse is CacheListFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
 
         Assert.Equal(hitResponse.StringList(), contentList);
@@ -569,7 +569,7 @@ public class ListTest : TestBase
         await client.ListPushFrontAsync(cacheName, listName, field1, true, ttl: TimeSpan.FromSeconds(10));
 
         CacheListFetchResponse fetchResponse = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(fetchResponse is CacheListFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
 
         Assert.Contains(field1, hitResponse.ByteArrayList!);
@@ -584,7 +584,7 @@ public class ListTest : TestBase
     public async Task ListRemoveValueAsync_NullChecksByteArray_IsError(string cacheName, string listName, byte[] value)
     {
         CacheListRemoveValueResponse response = await client.ListRemoveValueAsync(cacheName, listName, value);
-        Assert.True(response is CacheListRemoveValueResponse.Error);
+        Assert.True(response is CacheListRemoveValueResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListRemoveValueResponse.Error)response).ErrorCode);
     }
 
@@ -609,7 +609,7 @@ public class ListTest : TestBase
 
         // Test not there
         var response = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(response is CacheListFetchResponse.Hit);
+        Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var cachedList = ((CacheListFetchResponse.Hit)response).ByteArrayList!;
         Assert.True(list.ListEquals(cachedList));
     }
@@ -628,7 +628,7 @@ public class ListTest : TestBase
         await client.ListRemoveValueAsync(cacheName, listName, Utils.NewGuidByteArray());
 
         var response = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(response is CacheListFetchResponse.Hit);
+        Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var cachedList = ((CacheListFetchResponse.Hit)response).ByteArrayList!;
         Assert.True(list.ListEquals(cachedList));
     }
@@ -649,7 +649,7 @@ public class ListTest : TestBase
     public async Task ListRemoveValueAsync_NullChecksString_IsError(string cacheName, string listName, string value)
     {
         CacheListRemoveValueResponse response = await client.ListRemoveValueAsync(cacheName, listName, value);
-        Assert.True(response is CacheListRemoveValueResponse.Error);
+        Assert.True(response is CacheListRemoveValueResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListRemoveValueResponse.Error)response).ErrorCode);
     }
 
@@ -674,7 +674,7 @@ public class ListTest : TestBase
 
         // Test not there
         var response = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(response is CacheListFetchResponse.Hit);
+        Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var cachedList = ((CacheListFetchResponse.Hit)response).StringList()!;
         Assert.True(list.SequenceEqual(cachedList));
     }
@@ -693,7 +693,7 @@ public class ListTest : TestBase
         await client.ListRemoveValueAsync(cacheName, listName, Utils.NewGuidString());
 
         var response = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(response is CacheListFetchResponse.Hit);
+        Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var cachedList = ((CacheListFetchResponse.Hit)response).StringList()!;
         Assert.True(list.SequenceEqual(cachedList));
     }
@@ -713,7 +713,7 @@ public class ListTest : TestBase
     public async Task ListLengthAsync_NullChecks_IsError(string cacheName, string listName)
     {
         CacheListLengthResponse response = await client.ListLengthAsync(cacheName, listName);
-        Assert.True(response is CacheListLengthResponse.Error);
+        Assert.True(response is CacheListLengthResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListLengthResponse.Error)response).ErrorCode);
     }
 
@@ -721,7 +721,7 @@ public class ListTest : TestBase
     public async Task ListLengthAsync_ListIsMissing_HappyPath()
     {
         CacheListLengthResponse lengthResponse = await client.ListLengthAsync(cacheName, Utils.NewGuidString());
-        Assert.True(lengthResponse is CacheListLengthResponse.Success);
+        Assert.True(lengthResponse is CacheListLengthResponse.Success, $"Unexpected response: {lengthResponse}");
         var successResponse = (CacheListLengthResponse.Success)lengthResponse;
         Assert.Equal(0, successResponse.Length);
     }
@@ -736,7 +736,7 @@ public class ListTest : TestBase
         }
 
         CacheListLengthResponse lengthResponse = await client.ListLengthAsync(cacheName, listName);
-        Assert.True(lengthResponse is CacheListLengthResponse.Success);
+        Assert.True(lengthResponse is CacheListLengthResponse.Success, $"Unexpected response: {lengthResponse}");
         var successResponse = (CacheListLengthResponse.Success)lengthResponse;
         Assert.Equal(10, successResponse.Length);
     }
@@ -747,7 +747,7 @@ public class ListTest : TestBase
     public async Task ListDeleteAsync_NullChecks_IsError(string cacheName, string listName)
     {
         var response = await client.ListDeleteAsync(cacheName, listName);
-        Assert.True(response is CacheListDeleteResponse.Error);
+        Assert.True(response is CacheListDeleteResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListDeleteResponse.Error)response).ErrorCode);
     }
 
@@ -757,7 +757,7 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         Assert.True((await client.ListFetchAsync(cacheName, listName)) is CacheListFetchResponse.Miss);
         var deleteResponse = await client.ListDeleteAsync(cacheName, listName);
-        Assert.True(deleteResponse is CacheListDeleteResponse.Success);
+        Assert.True(deleteResponse is CacheListDeleteResponse.Success, $"Unexpected response: {deleteResponse}");
         Assert.True((await client.ListFetchAsync(cacheName, listName)) is CacheListFetchResponse.Miss);
     }
 
@@ -766,17 +766,17 @@ public class ListTest : TestBase
     {
         var listName = Utils.NewGuidString();
         var pushResponse = await client.ListPushFrontAsync(cacheName, listName, Utils.NewGuidString(), false);
-        Assert.True(pushResponse is CacheListPushFrontResponse.Success);
+        Assert.True(pushResponse is CacheListPushFrontResponse.Success, $"Unexpected response: {pushResponse}");
         pushResponse = await client.ListPushFrontAsync(cacheName, listName, Utils.NewGuidString(), false);
-        Assert.True(pushResponse is CacheListPushFrontResponse.Success);
+        Assert.True(pushResponse is CacheListPushFrontResponse.Success, $"Unexpected response: {pushResponse}");
         pushResponse = await client.ListPushFrontAsync(cacheName, listName, Utils.NewGuidString(), false);
-        Assert.True(pushResponse is CacheListPushFrontResponse.Success);
+        Assert.True(pushResponse is CacheListPushFrontResponse.Success, $"Unexpected response: {pushResponse}");
 
         Assert.True((await client.ListFetchAsync(cacheName, listName)) is CacheListFetchResponse.Hit);
         var deleteResponse = await client.ListDeleteAsync(cacheName, listName);
-        Assert.True(deleteResponse is CacheListDeleteResponse.Success);
+        Assert.True(deleteResponse is CacheListDeleteResponse.Success, $"Unexpected response: {deleteResponse}");
 
         var fetchResponse = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(fetchResponse is CacheListFetchResponse.Miss);
+        Assert.True(fetchResponse is CacheListFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
     }
 }

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/SetTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/SetTest.cs
@@ -18,7 +18,7 @@ public class SetTest : TestBase
     public async Task SetAddAsync_NullChecksByteArray_IsError(string cacheName, string setName, byte[] element)
     {
         CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, false);
-        Assert.True(response is CacheSetAddResponse.Error);
+        Assert.True(response is CacheSetAddResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddResponse.Error)response).ErrorCode);
     }
 
@@ -29,10 +29,10 @@ public class SetTest : TestBase
         var element = Utils.NewGuidByteArray();
 
         CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, false);
-        Assert.True(response is CacheSetAddResponse.Success);
+        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(fetchResponse is CacheSetFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
 
         var set = ((CacheSetFetchResponse.Hit)fetchResponse).ByteArraySet;
         Assert.Single(set);
@@ -46,14 +46,14 @@ public class SetTest : TestBase
         var element = Utils.NewGuidByteArray();
 
         CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, false, ttl: TimeSpan.FromSeconds(5));
-        Assert.True(response is CacheSetAddResponse.Success);
+        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(100);
 
         response = await client.SetAddAsync(cacheName, setName, element, false, ttl: TimeSpan.FromSeconds(10));
-        Assert.True(response is CacheSetAddResponse.Success);
+        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(4900);
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(fetchResponse is CacheSetFetchResponse.Miss);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
     }
 
     [Fact]
@@ -63,12 +63,12 @@ public class SetTest : TestBase
         var element = Utils.NewGuidByteArray();
 
         CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, false, ttl: TimeSpan.FromSeconds(2));
-        Assert.True(response is CacheSetAddResponse.Success);
+        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
         await client.SetAddAsync(cacheName, setName, element, true, ttl: TimeSpan.FromSeconds(10));
         await Task.Delay(2000);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(fetchResponse is CacheSetFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         Assert.Single(((CacheSetFetchResponse.Hit)fetchResponse).ByteArraySet);
     }
 
@@ -79,7 +79,7 @@ public class SetTest : TestBase
     public async Task SetAddAsync_NullChecksString_IsError(string cacheName, string setName, string element)
     {
         CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, false);
-        Assert.True(response is CacheSetAddResponse.Error);
+        Assert.True(response is CacheSetAddResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddResponse.Error)response).ErrorCode);
     }
 
@@ -90,10 +90,10 @@ public class SetTest : TestBase
         var element = Utils.NewGuidString();
 
         CacheSetAddResponse respose = await client.SetAddAsync(cacheName, setName, element, false);
-        Assert.True(respose is CacheSetAddResponse.Success);
+        Assert.True(respose is CacheSetAddResponse.Success, $"Unexpected response: {respose}");
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(fetchResponse is CacheSetFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
 
         var set = ((CacheSetFetchResponse.Hit)fetchResponse).StringSet();
         Assert.Single(set);
@@ -107,15 +107,15 @@ public class SetTest : TestBase
         var element = Utils.NewGuidString();
 
         CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, false, ttl: TimeSpan.FromSeconds(5));
-        Assert.True(response is CacheSetAddResponse.Success);
+        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(100);
 
         response = await client.SetAddAsync(cacheName, setName, element, false, ttl: TimeSpan.FromSeconds(10));
-        Assert.True(response is CacheSetAddResponse.Success);
+        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(4900);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(fetchResponse is CacheSetFetchResponse.Miss);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
     }
 
     [Fact]
@@ -125,13 +125,13 @@ public class SetTest : TestBase
         var element = Utils.NewGuidString();
 
         CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, false, ttl: TimeSpan.FromSeconds(2));
-        Assert.True(response is CacheSetAddResponse.Success);
+        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
         response = await client.SetAddAsync(cacheName, setName, element, true, ttl: TimeSpan.FromSeconds(10));
-        Assert.True(response is CacheSetAddResponse.Success);
+        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(2000);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(fetchResponse is CacheSetFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         Assert.Single(((CacheSetFetchResponse.Hit)fetchResponse).StringSet());
     }
 
@@ -141,18 +141,18 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var set = new HashSet<byte[]>();
         CacheSetAddBatchResponse response = await client.SetAddBatchAsync(null!, setName, set, false);
-        Assert.True(response is CacheSetAddBatchResponse.Error);
+        Assert.True(response is CacheSetAddBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddBatchResponse.Error)response).ErrorCode);
         response = await client.SetAddBatchAsync(cacheName, null!, set, false);
-        Assert.True(response is CacheSetAddBatchResponse.Error);
+        Assert.True(response is CacheSetAddBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddBatchResponse.Error)response).ErrorCode);
         response = await client.SetAddBatchAsync(cacheName, setName, (IEnumerable<byte[]>)null!, false);
-        Assert.True(response is CacheSetAddBatchResponse.Error);
+        Assert.True(response is CacheSetAddBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddBatchResponse.Error)response).ErrorCode);
 
         set.Add(null!);
         response = await client.SetAddBatchAsync(cacheName, setName, set, false);
-        Assert.True(response is CacheSetAddBatchResponse.Error);
+        Assert.True(response is CacheSetAddBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddBatchResponse.Error)response).ErrorCode);
     }
 
@@ -165,10 +165,10 @@ public class SetTest : TestBase
         var content = new List<byte[]>() { element1, element2 };
 
         CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, false, TimeSpan.FromSeconds(10));
-        Assert.True(response is CacheSetAddBatchResponse.Success);
+        Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(fetchResponse is CacheSetFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
 
         var set = ((CacheSetFetchResponse.Hit)fetchResponse).ByteArraySet;
         Assert.Equal(2, set!.Count);
@@ -184,15 +184,15 @@ public class SetTest : TestBase
         var content = new List<byte[]>() { element };
 
         CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, false, ttl: TimeSpan.FromSeconds(5));
-        Assert.True(response is CacheSetAddBatchResponse.Success);
+        Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(100);
 
         response = await client.SetAddBatchAsync(cacheName, setName, content, false, ttl: TimeSpan.FromSeconds(10));
-        Assert.True(response is CacheSetAddBatchResponse.Success);
+        Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(4900);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(fetchResponse is CacheSetFetchResponse.Miss);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
     }
 
     [Fact]
@@ -203,12 +203,12 @@ public class SetTest : TestBase
         var content = new List<byte[]>() { element };
 
         CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, false, ttl: TimeSpan.FromSeconds(2));
-        Assert.True(response is CacheSetAddBatchResponse.Success);
+        Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
         await client.SetAddBatchAsync(cacheName, setName, content, true, ttl: TimeSpan.FromSeconds(10));
         await Task.Delay(2000);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(fetchResponse is CacheSetFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
 
         var set = ((CacheSetFetchResponse.Hit)fetchResponse).ByteArraySet;
         Assert.Single(set);
@@ -221,18 +221,18 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var set = new HashSet<string>();
         CacheSetAddBatchResponse response = await client.SetAddBatchAsync(null!, setName, set, false);
-        Assert.True(response is CacheSetAddBatchResponse.Error);
+        Assert.True(response is CacheSetAddBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddBatchResponse.Error)response).ErrorCode);
         response = await client.SetAddBatchAsync(cacheName, null!, set, false);
-        Assert.True(response is CacheSetAddBatchResponse.Error);
+        Assert.True(response is CacheSetAddBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddBatchResponse.Error)response).ErrorCode);
         response = await client.SetAddBatchAsync(cacheName, setName, (IEnumerable<string>)null!, false);
-        Assert.True(response is CacheSetAddBatchResponse.Error);
+        Assert.True(response is CacheSetAddBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddBatchResponse.Error)response).ErrorCode);
 
         set.Add(null!);
         response = await client.SetAddBatchAsync(cacheName, setName, set, false);
-        Assert.True(response is CacheSetAddBatchResponse.Error);
+        Assert.True(response is CacheSetAddBatchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddBatchResponse.Error)response).ErrorCode);
     }
 
@@ -245,10 +245,10 @@ public class SetTest : TestBase
         var content = new List<string>() { element1, element2 };
 
         CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, false, TimeSpan.FromSeconds(10));
-        Assert.True(response is CacheSetAddBatchResponse.Success);
+        Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(fetchResponse is CacheSetFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
 
         var set = ((CacheSetFetchResponse.Hit)fetchResponse).StringSet();
         Assert.Equal(2, set!.Count);
@@ -264,15 +264,15 @@ public class SetTest : TestBase
         var content = new List<string>() { element };
 
         CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, false, ttl: TimeSpan.FromSeconds(5));
-        Assert.True(response is CacheSetAddBatchResponse.Success);
+        Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(100);
 
         response = await client.SetAddBatchAsync(cacheName, setName, content, false, ttl: TimeSpan.FromSeconds(10));
-        Assert.True(response is CacheSetAddBatchResponse.Success);
+        Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(4900);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(fetchResponse is CacheSetFetchResponse.Miss);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
     }
 
     [Fact]
@@ -283,13 +283,13 @@ public class SetTest : TestBase
         var content = new List<string>() { element };
 
         CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, false, ttl: TimeSpan.FromSeconds(2));
-        Assert.True(response is CacheSetAddBatchResponse.Success);
+        Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
         response = await client.SetAddBatchAsync(cacheName, setName, content, true, ttl: TimeSpan.FromSeconds(10));
-        Assert.True(response is CacheSetAddBatchResponse.Success);
+        Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(2000);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(fetchResponse is CacheSetFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
 
         var set = ((CacheSetFetchResponse.Hit)fetchResponse).StringSet();
         Assert.Single(set);
@@ -303,7 +303,7 @@ public class SetTest : TestBase
     public async Task SetRemoveElementAsync_NullChecksByteArray_IsError(string cacheName, string setName, byte[] element)
     {
         CacheSetRemoveElementResponse response = await client.SetRemoveElementAsync(cacheName, setName, element);
-        Assert.True(response is CacheSetRemoveElementResponse.Error);
+        Assert.True(response is CacheSetRemoveElementResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetRemoveElementResponse.Error)response).ErrorCode);
     }
 
@@ -314,23 +314,23 @@ public class SetTest : TestBase
         var element = Utils.NewGuidByteArray();
 
         CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, false);
-        Assert.True(response is CacheSetAddResponse.Success);
+        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
 
         // Remove element that is not there -- no-op
         CacheSetRemoveElementResponse removeResponse = await client.SetRemoveElementAsync(cacheName, setName, Utils.NewGuidByteArray());
-        Assert.True(removeResponse is CacheSetRemoveElementResponse.Success);
-        // Fetch the whole set and make sure response has element we expect 
+        Assert.True(removeResponse is CacheSetRemoveElementResponse.Success, $"Unexpected response: {removeResponse}");
+        // Fetch the whole set and make sure response has element we expect
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(fetchResponse is CacheSetFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var set = ((CacheSetFetchResponse.Hit)fetchResponse).ByteArraySet;
         Assert.Single(set);
         Assert.Contains(element, set);
 
         // Remove element
         removeResponse = await client.SetRemoveElementAsync(cacheName, setName, element);
-        Assert.True(removeResponse is CacheSetRemoveElementResponse.Success);
+        Assert.True(removeResponse is CacheSetRemoveElementResponse.Success, $"Unexpected response: {removeResponse}");
         fetchResponse = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(fetchResponse is CacheSetFetchResponse.Miss);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
     }
 
     [Fact]
@@ -344,7 +344,7 @@ public class SetTest : TestBase
 
         // Remove element that is not there -- no-op
         CacheSetRemoveElementResponse removeResponse = await client.SetRemoveElementAsync(cacheName, setName, Utils.NewGuidByteArray());
-        Assert.True(removeResponse is CacheSetRemoveElementResponse.Success);
+        Assert.True(removeResponse is CacheSetRemoveElementResponse.Success, $"Unexpected response: {removeResponse}");
 
         // Post-condition: set is still missing
         Assert.True(await client.SetFetchAsync(cacheName, setName) is CacheSetFetchResponse.Miss);
@@ -357,7 +357,7 @@ public class SetTest : TestBase
     public async Task SetRemoveElementAsync_NullChecksString_IsError(string cacheName, string setName, string element)
     {
         CacheSetRemoveElementResponse response = await client.SetRemoveElementAsync(cacheName, setName, element);
-        Assert.True(response is CacheSetRemoveElementResponse.Error);
+        Assert.True(response is CacheSetRemoveElementResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetRemoveElementResponse.Error)response).ErrorCode);
     }
 
@@ -368,22 +368,22 @@ public class SetTest : TestBase
         var element = Utils.NewGuidString();
 
         CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, false);
-        Assert.True(response is CacheSetAddResponse.Success);
+        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
 
         // Remove element that is not there -- no-op
         CacheSetRemoveElementResponse removeResponse = await client.SetRemoveElementAsync(cacheName, setName, Utils.NewGuidString());
-        Assert.True(removeResponse is CacheSetRemoveElementResponse.Success);
+        Assert.True(removeResponse is CacheSetRemoveElementResponse.Success, $"Unexpected response: {removeResponse}");
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(fetchResponse is CacheSetFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var set = ((CacheSetFetchResponse.Hit)fetchResponse).StringSet();
         Assert.Single(set);
         Assert.Contains(element, set);
 
         // Remove element
         removeResponse = await client.SetRemoveElementAsync(cacheName, setName, element);
-        Assert.True(removeResponse is CacheSetRemoveElementResponse.Success);
+        Assert.True(removeResponse is CacheSetRemoveElementResponse.Success, $"Unexpected response: {removeResponse}");
         fetchResponse = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(fetchResponse is CacheSetFetchResponse.Miss);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
     }
 
     [Fact]
@@ -397,7 +397,7 @@ public class SetTest : TestBase
 
         // Remove element that is not there -- no-op
         CacheSetRemoveElementResponse response = await client.SetRemoveElementAsync(cacheName, setName, Utils.NewGuidString());
-        Assert.True(response is CacheSetRemoveElementResponse.Success);
+        Assert.True(response is CacheSetRemoveElementResponse.Success, $"Unexpected response: {response}");
 
         // Post-condition: set is still missing
         Assert.True(await client.SetFetchAsync(cacheName, setName) is CacheSetFetchResponse.Miss);
@@ -410,30 +410,30 @@ public class SetTest : TestBase
         var testData = new byte[][][] { new byte[][] { Utils.NewGuidByteArray(), Utils.NewGuidByteArray() }, new byte[][] { Utils.NewGuidByteArray(), null! } };
 
         CacheSetRemoveElementsResponse response = await client.SetRemoveElementsAsync(null!, setName, testData[0]);
-        Assert.True(response is CacheSetRemoveElementsResponse.Error);
+        Assert.True(response is CacheSetRemoveElementsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetRemoveElementsResponse.Error)response).ErrorCode);
         response = await client.SetRemoveElementsAsync(cacheName, null!, testData[0]);
-        Assert.True(response is CacheSetRemoveElementsResponse.Error);
+        Assert.True(response is CacheSetRemoveElementsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetRemoveElementsResponse.Error)response).ErrorCode);
         response = await client.SetRemoveElementsAsync(cacheName, setName, (byte[][])null!);
-        Assert.True(response is CacheSetRemoveElementsResponse.Error);
+        Assert.True(response is CacheSetRemoveElementsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetRemoveElementsResponse.Error)response).ErrorCode);
         response = await client.SetRemoveElementsAsync(cacheName, setName, testData[1]);
-        Assert.True(response is CacheSetRemoveElementsResponse.Error);
+        Assert.True(response is CacheSetRemoveElementsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetRemoveElementsResponse.Error)response).ErrorCode);
 
         var fieldsList = new List<byte[]>(testData[0]);
         response = await client.SetRemoveElementsAsync(null!, setName, fieldsList);
-        Assert.True(response is CacheSetRemoveElementsResponse.Error);
+        Assert.True(response is CacheSetRemoveElementsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetRemoveElementsResponse.Error)response).ErrorCode);
         response = await client.SetRemoveElementsAsync(cacheName, null!, fieldsList);
-        Assert.True(response is CacheSetRemoveElementsResponse.Error);
+        Assert.True(response is CacheSetRemoveElementsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetRemoveElementsResponse.Error)response).ErrorCode);
         response = await client.SetRemoveElementsAsync(cacheName, setName, (List<byte[]>)null!);
-        Assert.True(response is CacheSetRemoveElementsResponse.Error);
+        Assert.True(response is CacheSetRemoveElementsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetRemoveElementsResponse.Error)response).ErrorCode);
         response = await client.SetRemoveElementsAsync(cacheName, setName, new List<byte[]>(testData[1]));
-        Assert.True(response is CacheSetRemoveElementsResponse.Error);
+        Assert.True(response is CacheSetRemoveElementsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetRemoveElementsResponse.Error)response).ErrorCode);
     }
 
@@ -446,17 +446,17 @@ public class SetTest : TestBase
 
         // Test enumerable
         CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, elements[0], false);
-        Assert.True(response is CacheSetAddResponse.Success);
+        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
         await client.SetAddAsync(cacheName, setName, elements[1], false);
-        Assert.True(response is CacheSetAddResponse.Success);
+        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
         await client.SetAddAsync(cacheName, setName, otherElement, false);
-        Assert.True(response is CacheSetAddResponse.Success);
+        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
 
         var elementsList = new List<byte[]>(elements);
         CacheSetRemoveElementsResponse removeResponse = await client.SetRemoveElementsAsync(cacheName, setName, elementsList);
-        Assert.True(removeResponse is CacheSetRemoveElementsResponse.Success);
+        Assert.True(removeResponse is CacheSetRemoveElementsResponse.Success, $"Unexpected response: {removeResponse}");
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(fetchResponse is CacheSetFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheSetFetchResponse.Hit)fetchResponse;
         Assert.Single(hitResponse.ByteArraySet!);
         Assert.Contains(otherElement, hitResponse.ByteArraySet!);
@@ -469,30 +469,30 @@ public class SetTest : TestBase
         var testData = new string[][] { new string[] { Utils.NewGuidString(), Utils.NewGuidString() }, new string[] { Utils.NewGuidString(), null! } };
 
         CacheSetRemoveElementsResponse response = await client.SetRemoveElementsAsync(null!, setName, testData[0]);
-        Assert.True(response is CacheSetRemoveElementsResponse.Error);
+        Assert.True(response is CacheSetRemoveElementsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetRemoveElementsResponse.Error)response).ErrorCode);
         response = await client.SetRemoveElementsAsync(cacheName, null!, testData[0]);
-        Assert.True(response is CacheSetRemoveElementsResponse.Error);
+        Assert.True(response is CacheSetRemoveElementsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetRemoveElementsResponse.Error)response).ErrorCode);
         response = await client.SetRemoveElementsAsync(cacheName, setName, (byte[][])null!);
-        Assert.True(response is CacheSetRemoveElementsResponse.Error);
+        Assert.True(response is CacheSetRemoveElementsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetRemoveElementsResponse.Error)response).ErrorCode);
         response = await client.SetRemoveElementsAsync(cacheName, setName, testData[1]);
-        Assert.True(response is CacheSetRemoveElementsResponse.Error);
+        Assert.True(response is CacheSetRemoveElementsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetRemoveElementsResponse.Error)response).ErrorCode);
 
         var elementsList = new List<string>(testData[0]);
         response = await client.SetRemoveElementsAsync(null!, setName, elementsList);
-        Assert.True(response is CacheSetRemoveElementsResponse.Error);
+        Assert.True(response is CacheSetRemoveElementsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetRemoveElementsResponse.Error)response).ErrorCode);
         response = await client.SetRemoveElementsAsync(cacheName, null!, elementsList);
-        Assert.True(response is CacheSetRemoveElementsResponse.Error);
+        Assert.True(response is CacheSetRemoveElementsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetRemoveElementsResponse.Error)response).ErrorCode);
         response = await client.SetRemoveElementsAsync(cacheName, setName, (List<string>)null!);
-        Assert.True(response is CacheSetRemoveElementsResponse.Error);
+        Assert.True(response is CacheSetRemoveElementsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetRemoveElementsResponse.Error)response).ErrorCode);
         response = await client.SetRemoveElementsAsync(cacheName, setName, new List<string>(testData[1]));
-        Assert.True(response is CacheSetRemoveElementsResponse.Error);
+        Assert.True(response is CacheSetRemoveElementsResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetRemoveElementsResponse.Error)response).ErrorCode);
     }
 
@@ -505,17 +505,17 @@ public class SetTest : TestBase
 
         // Test enumerable
         CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, elements[0], false);
-        Assert.True(response is CacheSetAddResponse.Success);
+        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
         response = await client.SetAddAsync(cacheName, setName, elements[1], false);
-        Assert.True(response is CacheSetAddResponse.Success);
+        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
         response = await client.SetAddAsync(cacheName, setName, otherElement, false);
-        Assert.True(response is CacheSetAddResponse.Success);
+        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
 
         var elementsList = new List<string>(elements);
         CacheSetRemoveElementsResponse removeResponse = await client.SetRemoveElementsAsync(cacheName, setName, elementsList);
-        Assert.True(removeResponse is CacheSetRemoveElementsResponse.Success);
+        Assert.True(removeResponse is CacheSetRemoveElementsResponse.Success, $"Unexpected response: {removeResponse}");
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(fetchResponse is CacheSetFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheSetFetchResponse.Hit)fetchResponse;
         Assert.Single(hitResponse.ByteArraySet!);
         Assert.Contains(otherElement, hitResponse.ByteArraySet!);
@@ -527,7 +527,7 @@ public class SetTest : TestBase
     public async Task SetFetchAsync_NullChecks_IsError(string cacheName, string setName)
     {
         CacheSetFetchResponse response = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(response is CacheSetFetchResponse.Error);
+        Assert.True(response is CacheSetFetchResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetFetchResponse.Error)response).ErrorCode);
     }
 
@@ -536,7 +536,7 @@ public class SetTest : TestBase
     {
         var setName = Utils.NewGuidString();
         CacheSetFetchResponse response = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(response is CacheSetFetchResponse.Miss);
+        Assert.True(response is CacheSetFetchResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -544,9 +544,9 @@ public class SetTest : TestBase
     {
         var setName = Utils.NewGuidString();
         CacheSetAddBatchResponse setResponse = await client.SetAddBatchAsync(cacheName, setName, new string[] { Utils.NewGuidString(), Utils.NewGuidString() }, false);
-        Assert.True(setResponse is CacheSetAddBatchResponse.Success);
+        Assert.True(setResponse is CacheSetAddBatchResponse.Success, $"Unexpected response: {setResponse}");
         CacheSetFetchResponse response = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(response is CacheSetFetchResponse.Hit);
+        Assert.True(response is CacheSetFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheSetFetchResponse.Hit)response;
         var set1 = hitResponse.ByteArraySet;
         var set2 = hitResponse.ByteArraySet;
@@ -558,9 +558,9 @@ public class SetTest : TestBase
     {
         var setName = Utils.NewGuidString();
         CacheSetAddBatchResponse setResponse = await client.SetAddBatchAsync(cacheName, setName, new string[] { Utils.NewGuidString(), Utils.NewGuidString() }, false);
-        Assert.True(setResponse is CacheSetAddBatchResponse.Success);
+        Assert.True(setResponse is CacheSetAddBatchResponse.Success, $"Unexpected response: {setResponse}");
         CacheSetFetchResponse response = await client.SetFetchAsync(cacheName, setName);
-        Assert.True(response is CacheSetFetchResponse.Hit);
+        Assert.True(response is CacheSetFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheSetFetchResponse.Hit)response;
         var set1 = hitResponse.StringSet();
         var set2 = hitResponse.StringSet();
@@ -573,7 +573,7 @@ public class SetTest : TestBase
     public async Task SetDeleteAsync_NullChecks_IsError(string cacheName, string setName)
     {
         CacheSetDeleteResponse response = await client.SetDeleteAsync(cacheName, setName);
-        Assert.True(response is CacheSetDeleteResponse.Error);
+        Assert.True(response is CacheSetDeleteResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetDeleteResponse.Error)response).ErrorCode);
     }
 
@@ -583,7 +583,7 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         Assert.True(await client.SetFetchAsync(cacheName, setName) is CacheSetFetchResponse.Miss);
         CacheSetDeleteResponse response = await client.SetDeleteAsync(cacheName, setName);
-        Assert.True(response is CacheSetDeleteResponse.Success);
+        Assert.True(response is CacheSetDeleteResponse.Success, $"Unexpected response: {response}");
         Assert.True(await client.SetFetchAsync(cacheName, setName) is CacheSetFetchResponse.Miss);
     }
 
@@ -592,15 +592,15 @@ public class SetTest : TestBase
     {
         var setName = Utils.NewGuidString();
         CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, Utils.NewGuidString(), false);
-        Assert.True(response is CacheSetAddResponse.Success);
+        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
         response = await client.SetAddAsync(cacheName, setName, Utils.NewGuidString(), false);
-        Assert.True(response is CacheSetAddResponse.Success);
+        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
         response = await client.SetAddAsync(cacheName, setName, Utils.NewGuidString(), false);
-        Assert.True(response is CacheSetAddResponse.Success);
+        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
 
         Assert.True(await client.SetFetchAsync(cacheName, setName) is CacheSetFetchResponse.Hit);
         CacheSetDeleteResponse deleteResponse = await client.SetDeleteAsync(cacheName, setName);
-        Assert.True(deleteResponse is CacheSetDeleteResponse.Success);
+        Assert.True(deleteResponse is CacheSetDeleteResponse.Success, $"Unexpected response: {deleteResponse}");
         Assert.True(await client.SetFetchAsync(cacheName, setName) is CacheSetFetchResponse.Miss);
     }
 }


### PR DESCRIPTION
Prior to this commit, if one of our type assertions failed in
a test, we didn't get any information about the cause of the error.
This commit changes the assertions to use the signature that allows
us to provide an error message, and in the error message we include
the return value so that it is visible for debugging.
