### PR TITLE
feat: add support for ListConcatenateFront and ListConcatenateBack

### DIFF
--- a/src/Momento.Sdk.Incubating/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk.Incubating/Internal/ScsDataClient.cs
@@ -622,6 +622,81 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheSetDeleteResponse.Success();
     }
 
+    public async Task<CacheListConcatenateFrontResponse> ListConcatenateFrontAsync(string cacheName, string listName, IEnumerable<byte[]> values, bool refreshTtl, int? truncateBackToSize = null, TimeSpan? ttl = null)
+    {
+        return await SendListConcatenateFrontAsync(cacheName, listName, values.Select(value => value.ToByteString()), refreshTtl, truncateBackToSize, ttl);
+    }
+    public async Task<CacheListConcatenateFrontResponse> ListConcatenateFrontAsync(string cacheName, string listName, IEnumerable<string> values, bool refreshTtl, int? truncateBackToSize = null, TimeSpan? ttl = null)
+    {
+        return await SendListConcatenateFrontAsync(cacheName, listName, values.Select(value => value.ToByteString()), refreshTtl, truncateBackToSize, ttl);
+    }
+
+    public async Task<CacheListConcatenateFrontResponse> SendListConcatenateFrontAsync(string cacheName, string listName, IEnumerable<ByteString> values, bool refreshTtl, int? truncateBackToSize = null, TimeSpan? ttl = null)
+    {
+        _ListConcatenateFrontRequest request = new()
+        {
+            TruncateBackToSize = Convert.ToUInt32(truncateBackToSize.GetValueOrDefault()),
+            ListName = listName.ToByteString(),
+            RefreshTtl = refreshTtl,
+            TtlMilliseconds = TtlToMilliseconds(ttl)
+        };
+        request.Values.Add(values);
+        _ListConcatenateFrontResponse response;
+
+        try
+        {
+            response = await this.grpcManager.Client.ListConcatenateFrontAsync(request, new CallOptions(headers: MetadataWithCache(cacheName), deadline: CalculateDeadline()));
+        }
+        catch (Exception e)
+        {
+            var exc = _exceptionMapper.Convert(e);
+            if (exc.TransportDetails != null)
+            {
+                exc.TransportDetails.Grpc.Metadata = MetadataWithCache(cacheName);
+            }
+            return new CacheListConcatenateFrontResponse.Error(exc);
+        }
+        return new CacheListConcatenateFrontResponse.Success(response);
+    }
+
+    public async Task<CacheListConcatenateBackResponse> ListConcatenateBackAsync(string cacheName, string listName, IEnumerable<byte[]> values, bool refreshTtl, int? truncateFrontToSize = null, TimeSpan? ttl = null)
+    {
+        return await SendListConcatenateBackAsync(cacheName, listName, values.Select(value => value.ToByteString()), refreshTtl, truncateFrontToSize, ttl);
+    }
+    public async Task<CacheListConcatenateBackResponse> ListConcatenateBackAsync(string cacheName, string listName, IEnumerable<string> values, bool refreshTtl, int? truncateFrontToSize = null, TimeSpan? ttl = null)
+    {
+        return await SendListConcatenateBackAsync(cacheName, listName, values.Select(value => value.ToByteString()), refreshTtl, truncateFrontToSize, ttl);
+    }
+
+    public async Task<CacheListConcatenateBackResponse> SendListConcatenateBackAsync(string cacheName, string listName, IEnumerable<ByteString> values, bool refreshTtl, int? truncateFrontToSize = null, TimeSpan? ttl = null)
+    {
+        _ListConcatenateBackRequest request = new()
+        {
+            TruncateFrontToSize = Convert.ToUInt32(truncateFrontToSize.GetValueOrDefault()),
+            ListName = listName.ToByteString(),
+            RefreshTtl = refreshTtl,
+            TtlMilliseconds = TtlToMilliseconds(ttl)
+        };
+        request.Values.Add(values);
+        _ListConcatenateBackResponse response;
+
+        try
+        {
+            response = await this.grpcManager.Client.ListConcatenateBackAsync(request, new CallOptions(headers: MetadataWithCache(cacheName), deadline: CalculateDeadline()));
+        }
+        catch (Exception e)
+        {
+            var exc = _exceptionMapper.Convert(e);
+            if (exc.TransportDetails != null)
+            {
+                exc.TransportDetails.Grpc.Metadata = MetadataWithCache(cacheName);
+            }
+            return new CacheListConcatenateBackResponse.Error(exc);
+        }
+        return new CacheListConcatenateBackResponse.Success(response);
+    }
+
+
     public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, byte[] value, bool refreshTtl, int? truncateBackToSize = null, TimeSpan? ttl = null)
     {
         return await SendListPushFrontAsync(cacheName, listName, value.ToByteString(), refreshTtl, truncateBackToSize, ttl);

--- a/src/Momento.Sdk.Incubating/Momento.Sdk.Incubating.csproj
+++ b/src/Momento.Sdk.Incubating/Momento.Sdk.Incubating.csproj
@@ -34,10 +34,9 @@
 		<RepositoryUrl>https://github.com/momentohq/client-sdk-dotnet-incubating</RepositoryUrl>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Momento.Sdk" Version="0.38.1" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
+    <PackageReference Include="Momento.Sdk" Version="0.38.2" />
+	</ItemGroup>
+	<ItemGroup>
+	  <ProjectReference Include="..\..\..\client-sdk-dotnet\src\Momento.Sdk\Momento.Sdk.csproj" />
 	</ItemGroup>
 </Project>

--- a/src/Momento.Sdk.Incubating/Responses/CacheListConcatenateBackResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheListConcatenateBackResponse.cs
@@ -1,0 +1,49 @@
+using Momento.Protos.CacheClient;
+using Momento.Sdk.Exceptions;
+
+namespace Momento.Sdk.Incubating.Responses;
+
+/// <summary>
+/// The result of a <c>ListConcatenateBack</c> command
+/// </summary>
+///
+public abstract class CacheListConcatenateBackResponse
+{
+    public class Success : CacheListConcatenateBackResponse
+    {
+        public int ListLength { get; private set; }
+        public Success(_ListConcatenateBackResponse response)
+        {
+            ListLength = checked((int)response.ListLength);
+        }
+    }
+    public class Error : CacheListConcatenateBackResponse
+    {
+        private readonly SdkException _error;
+        public Error(SdkException error)
+        {
+            _error = error;
+        }
+
+        public SdkException Exception
+        {
+            get => _error;
+        }
+
+        public MomentoErrorCode ErrorCode
+        {
+            get => _error.ErrorCode;
+        }
+
+        public string Message
+        {
+            get => $"{_error.MessageWrapper}: {_error.Message}";
+        }
+
+        public override string ToString()
+        {
+            return base.ToString() + ": " + Message;
+        }
+    }
+
+}

--- a/src/Momento.Sdk.Incubating/Responses/CacheListConcatenateFrontResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheListConcatenateFrontResponse.cs
@@ -1,0 +1,49 @@
+using Momento.Protos.CacheClient;
+using Momento.Sdk.Exceptions;
+
+namespace Momento.Sdk.Incubating.Responses;
+
+/// <summary>
+/// The result of a <c>ListConcatenateFront</c> command
+/// </summary>
+///
+public abstract class CacheListConcatenateFrontResponse
+{
+    public class Success : CacheListConcatenateFrontResponse
+    {
+        public int ListLength { get; private set; }
+        public Success(_ListConcatenateFrontResponse response)
+        {
+            ListLength = checked((int)response.ListLength);
+        }
+    }
+    public class Error : CacheListConcatenateFrontResponse
+    {
+        private readonly SdkException _error;
+        public Error(SdkException error)
+        {
+            _error = error;
+        }
+
+        public SdkException Exception
+        {
+            get => _error;
+        }
+
+        public MomentoErrorCode ErrorCode
+        {
+            get => _error.ErrorCode;
+        }
+
+        public string Message
+        {
+            get => $"{_error.MessageWrapper}: {_error.Message}";
+        }
+
+        public override string ToString()
+        {
+            return base.ToString() + ": " + Message;
+        }
+    }
+
+}

--- a/src/Momento.Sdk.Incubating/SimpleCacheClient.cs
+++ b/src/Momento.Sdk.Incubating/SimpleCacheClient.cs
@@ -819,6 +819,117 @@ public class SimpleCacheClient : ISimpleCacheClient
     }
 
     /// <summary>
+    /// Pushes multiple values to the beginning of a list.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to store the list in.</param>
+    /// <param name="listName">The list to push the value on.</param>
+    /// <param name="values">The values to push to the front of the list.</param>
+    /// <param name="refreshTtl">Update <paramref name="listName"/>'s TTL if it already exists.</param>
+    /// <param name="ttl">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <param name="truncateBackToSize">Ensure the list does not exceed this length. Remove excess from the end of the list. Must be a positive number.</param>
+    /// <returns>Task representing the result of the push operation.</returns>
+    public async Task<CacheListConcatenateFrontResponse> ListConcatenateFrontAsync(string cacheName, string listName, IEnumerable<byte[]> values, bool refreshTtl, TimeSpan? ttl = null, int? truncateBackToSize = null)
+    {
+        try
+        {
+            Utils.ArgumentNotNull(cacheName, nameof(cacheName));
+            Utils.ArgumentNotNull(listName, nameof(listName));
+            Utils.ArgumentNotNull(values, nameof(values));
+            Utils.ElementsNotNull(values, nameof(values));
+            Utils.ArgumentStrictlyPositive(truncateBackToSize, nameof(truncateBackToSize));
+        }
+        catch (ArgumentNullException e)
+        {
+            return new CacheListConcatenateFrontResponse.Error(new InvalidArgumentException(e.Message));
+        }
+        catch (ArgumentOutOfRangeException e)
+        {
+            return new CacheListConcatenateFrontResponse.Error(new InvalidArgumentException(e.Message));
+        }
+
+        return await this.dataClient.ListConcatenateFrontAsync(cacheName, listName, values, refreshTtl, truncateBackToSize, ttl);
+    }
+
+    /// <inheritdoc cref="ListConcatenateFrontAsync(string, string, IEnumerable{byte[]}, bool, TimeSpan?, int?)"/>
+    public async Task<CacheListConcatenateFrontResponse> ListConcatenateFrontAsync(string cacheName, string listName, IEnumerable<string> values, bool refreshTtl, TimeSpan? ttl = null, int? truncateBackToSize = null)
+    {
+        try
+        {
+            Utils.ArgumentNotNull(cacheName, nameof(cacheName));
+            Utils.ArgumentNotNull(listName, nameof(listName));
+            Utils.ArgumentNotNull(values, nameof(values));
+            Utils.ElementsNotNull(values, nameof(values));
+            Utils.ArgumentStrictlyPositive(truncateBackToSize, nameof(truncateBackToSize));
+        }
+        catch (ArgumentNullException e)
+        {
+            return new CacheListConcatenateFrontResponse.Error(new InvalidArgumentException(e.Message));
+        }
+        catch (ArgumentOutOfRangeException e)
+        {
+            return new CacheListConcatenateFrontResponse.Error(new InvalidArgumentException(e.Message));
+        }
+
+        return await this.dataClient.ListConcatenateFrontAsync(cacheName, listName, values, refreshTtl, truncateBackToSize, ttl);
+    }
+
+    /// <summary>
+    /// Pushes multiple values to the back of a list.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to store the list in.</param>
+    /// <param name="listName">The list to push the value on.</param>
+    /// <param name="values">The values to push to the front of the list.</param>
+    /// <param name="refreshTtl">Update <paramref name="listName"/>'s TTL if it already exists.</param>
+    /// <param name="ttl">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <param name="truncateFrontToSize">Ensure the list does not exceed this length. Remove excess from the front of the list. Must be a positive number.</param>
+    /// <returns>Task representing the result of the push operation.</returns>
+    public async Task<CacheListConcatenateBackResponse> ListConcatenateBackAsync(string cacheName, string listName, IEnumerable<byte[]> values, bool refreshTtl, TimeSpan? ttl = null, int? truncateFrontToSize = null)
+    {
+        try
+        {
+            Utils.ArgumentNotNull(cacheName, nameof(cacheName));
+            Utils.ArgumentNotNull(listName, nameof(listName));
+            Utils.ArgumentNotNull(values, nameof(values));
+            Utils.ElementsNotNull(values, nameof(values));
+            Utils.ArgumentStrictlyPositive(truncateFrontToSize, nameof(truncateFrontToSize));
+        }
+        catch (ArgumentNullException e)
+        {
+            return new CacheListConcatenateBackResponse.Error(new InvalidArgumentException(e.Message));
+        }
+        catch (ArgumentOutOfRangeException e)
+        {
+            return new CacheListConcatenateBackResponse.Error(new InvalidArgumentException(e.Message));
+        }
+
+        return await this.dataClient.ListConcatenateBackAsync(cacheName, listName, values, refreshTtl, truncateFrontToSize, ttl);
+    }
+
+    /// <inheritdoc cref="ListConcatenateBackAsync(string, string, IEnumerable{byte[]}, bool, TimeSpan?, int?)"/>
+    public async Task<CacheListConcatenateBackResponse> ListConcatenateBackAsync(string cacheName, string listName, IEnumerable<string> values, bool refreshTtl, TimeSpan? ttl = null, int? truncateFrontToSize = null)
+    {
+         try
+        {
+            Utils.ArgumentNotNull(cacheName, nameof(cacheName));
+            Utils.ArgumentNotNull(listName, nameof(listName));
+            Utils.ArgumentNotNull(values, nameof(values));
+            Utils.ElementsNotNull(values, nameof(values));
+            Utils.ArgumentStrictlyPositive(truncateFrontToSize, nameof(truncateFrontToSize));
+        }
+        catch (ArgumentNullException e)
+        {
+            return new CacheListConcatenateBackResponse.Error(new InvalidArgumentException(e.Message));
+        }
+        catch (ArgumentOutOfRangeException e)
+        {
+            return new CacheListConcatenateBackResponse.Error(new InvalidArgumentException(e.Message));
+        }
+
+        return await this.dataClient.ListConcatenateBackAsync(cacheName, listName, values, refreshTtl, truncateFrontToSize, ttl);
+    }
+
+
+    /// <summary>
     /// Push a value to the beginning of a list.
     /// </summary>
     /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, TimeSpan?)" path="remark"/>
@@ -870,7 +981,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         }
 
         return await this.dataClient.ListPushFrontAsync(cacheName, listName, value, refreshTtl, truncateBackToSize, ttl);
-    }
+    } 
 
     /// <summary>
     /// Push a value to the end of a list.

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
@@ -11,6 +11,342 @@ public class ListTest : TestBase
     }
 
     [Theory]
+    [InlineData(null, "my-list", new string[] {"value"})]
+    [InlineData("cache", null,  new string[] {"value"})]
+    [InlineData("cache", "my-list", null)]
+    public async Task ListConcatenateFrontAsync_NullChecksStringArray_IsError(string cacheName, string listName, IEnumerable<string> values)
+    {
+        CacheListConcatenateFrontResponse response = await client.ListConcatenateFrontAsync(cacheName, listName, values, false);
+        Assert.True(response is CacheListConcatenateFrontResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListConcatenateFrontResponse.Error)response).ErrorCode);
+    }
+
+    [Fact]
+    public async Task ListConcatenateFrontFetch_ValueIsByteArray_HappyPath()
+    {
+        var listName = Utils.NewGuidString();
+        byte[][] values1 = new byte[][] { Utils.NewGuidByteArray(), Utils.NewGuidByteArray() };
+
+        CacheListConcatenateFrontResponse concatenateResponse = await client.ListConcatenateFrontAsync(cacheName, listName, values1, false);
+        Assert.True(concatenateResponse is CacheListConcatenateFrontResponse.Success, $"Unexpected response: {concatenateResponse}");
+        Assert.Equal(1, ((CacheListConcatenateFrontResponse.Success)concatenateResponse).ListLength);
+
+        CacheListFetchResponse fetchResponse = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
+        var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
+
+        var list = hitResponse.ByteArrayList;
+        Assert.NotEmpty(list);
+        foreach (byte[] value in values1) {
+            Assert.Contains(value, list);
+        }
+
+        // Test adding at the front semantics
+        byte[][] values2 = new byte[][] { Utils.NewGuidByteArray(), Utils.NewGuidByteArray() };
+        concatenateResponse = await client.ListConcatenateFrontAsync(cacheName, listName, values2, false);
+        Assert.True(concatenateResponse is CacheListConcatenateFrontResponse.Success, $"Unexpected response: {concatenateResponse}");
+        var successResponse = (CacheListConcatenateFrontResponse.Success)concatenateResponse;
+        Assert.Equal(4, successResponse.ListLength);
+
+        fetchResponse = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
+        hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
+        list = hitResponse.ByteArrayList!;
+        for (int i = 0; i < values2.Length; i++) {
+            Assert.Equal(values2[i], list[i]);
+        }
+        foreach (byte[] value in values1) {
+            Assert.Contains(value, list);
+        }
+    }
+
+    [Fact]
+    public async Task ListConcatenateFrontFetch_ValueIsByteArray_NoRefreshTtl()
+    {
+        var listName = Utils.NewGuidString();
+        byte[][] values = new byte[][] { Utils.NewGuidByteArray() };
+
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, false, ttl: TimeSpan.FromSeconds(5));
+        await Task.Delay(100);
+
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, false, ttl: TimeSpan.FromSeconds(5));
+        await Task.Delay(4900);
+
+        CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
+    }
+
+    [Fact]
+    public async Task ListConcatenateFrontFetch_ValueIsByteArray_RefreshTtl()
+    {
+        var listName = Utils.NewGuidString();
+        byte[][] values = new byte[][] { Utils.NewGuidByteArray() };
+
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, false, ttl: TimeSpan.FromSeconds(2));
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, true, ttl: TimeSpan.FromSeconds(10));
+        await Task.Delay(2000);
+
+        CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
+        var hitResponse = (CacheListFetchResponse.Hit)response;
+        Assert.Equal(2, hitResponse.ByteArrayList!.Count);
+    }
+
+    [Fact]
+    public async Task ListConcatenateFrontAsync_ValueIsByteArrayTruncateBackToSizeIsZero_IsError()
+    {
+        byte[][] values = new byte[][] { };
+        var response = await client.ListConcatenateFrontAsync("myCache", "listName", values, false, truncateBackToSize: 0);
+        Assert.True(response is CacheListConcatenateFrontResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListConcatenateFrontResponse.Error)response).ErrorCode);
+    }
+
+    [Fact]
+    public async Task ListConcatenateFrontFetch_ValueIsStringArray_HappyPath()
+    {
+        var listName = Utils.NewGuidString();
+        string[] values1 = new string[] { Utils.NewGuidString(), Utils.NewGuidString() };
+
+        CacheListConcatenateFrontResponse concatenateResponse = await client.ListConcatenateFrontAsync(cacheName, listName, values1, false);
+        Assert.True(concatenateResponse is CacheListConcatenateFrontResponse.Success, $"Unexpected response: {concatenateResponse}");
+        Assert.Equal(1, ((CacheListConcatenateFrontResponse.Success)concatenateResponse).ListLength);
+
+        CacheListFetchResponse fetchResponse = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
+        var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
+
+        var list = hitResponse.StringList()!;
+        Assert.NotEmpty(list);
+        foreach (string value in values1) {
+            Assert.Contains(value, list);
+        }
+
+        // Test adding at the front semantics
+        string[] values2 = new string[] { Utils.NewGuidString(), Utils.NewGuidString() };
+        concatenateResponse = await client.ListConcatenateFrontAsync(cacheName, listName, values2, false);
+        Assert.True(concatenateResponse is CacheListConcatenateFrontResponse.Success, $"Unexpected response: {concatenateResponse}");
+        var successResponse = (CacheListConcatenateFrontResponse.Success)concatenateResponse;
+        Assert.Equal(4, successResponse.ListLength);
+
+        fetchResponse = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
+        hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
+        list = hitResponse.StringList()!;
+        var values3 = new List<String>(values2);
+        values3.AddRange(values1);
+        Assert.Equal(values3, list);
+    }
+
+    [Fact]
+    public async Task ListConcatenateFrontFetch_ValueIsStringArray_NoRefreshTtl()
+    {
+        var listName = Utils.NewGuidString();
+        string[] values = new string[] { Utils.NewGuidString() };
+
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, false, ttl: TimeSpan.FromSeconds(5));
+        await Task.Delay(100);
+
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, false, ttl: TimeSpan.FromSeconds(5));
+        await Task.Delay(4900);
+
+        CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
+    }
+
+    [Fact]
+    public async Task ListConcatenateFrontFetch_ValueIsStringArray_RefreshTtl()
+    {
+        var listName = Utils.NewGuidString();
+        string[] values = new string[] { Utils.NewGuidString() };
+
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, false, ttl: TimeSpan.FromSeconds(2));
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, true, ttl: TimeSpan.FromSeconds(10));
+        await Task.Delay(2000);
+
+        CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
+        var hitResponse = (CacheListFetchResponse.Hit)response;
+        Assert.Equal(2, hitResponse.ByteArrayList!.Count);
+    }
+
+    [Fact]
+    public async Task ListConcatenateFrontAsync_ValueIsStringArrayTruncateBackToSizeIsZero_IsError()
+    {
+        string[] values = new string[] { };
+        var response = await client.ListConcatenateFrontAsync("myCache", "listName", values, false, truncateBackToSize: 0);
+        Assert.True(response is CacheListConcatenateFrontResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListConcatenateFrontResponse.Error)response).ErrorCode);
+    }
+
+[Theory]
+    [InlineData(null, "my-list", new string[] {"value"})]
+    [InlineData("cache", null,  new string[] {"value"})]
+    [InlineData("cache", "my-list", null)]
+    public async Task ListConcatenateBackAsync_NullChecksStringArray_IsError(string cacheName, string listName, IEnumerable<string> values)
+    {
+        CacheListConcatenateBackResponse response = await client.ListConcatenateBackAsync(cacheName, listName, values, false);
+        Assert.True(response is CacheListConcatenateBackResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListConcatenateBackResponse.Error)response).ErrorCode);
+    }
+
+    [Fact]
+    public async Task ListConcatenateBackFetch_ValueIsByteArray_HappyPath()
+    {
+        var listName = Utils.NewGuidString();
+        byte[][] values1 = new byte[][] { Utils.NewGuidByteArray(), Utils.NewGuidByteArray() };
+
+        CacheListConcatenateBackResponse concatenateResponse = await client.ListConcatenateBackAsync(cacheName, listName, values1, false);
+        Assert.True(concatenateResponse is CacheListConcatenateBackResponse.Success, $"Unexpected response: {concatenateResponse}");
+        Assert.Equal(1, ((CacheListConcatenateBackResponse.Success)concatenateResponse).ListLength);
+
+        CacheListFetchResponse fetchResponse = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
+        var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
+
+        var list = hitResponse.ByteArrayList;
+        Assert.NotEmpty(list);
+        foreach (byte[] value in values1) {
+            Assert.Contains(value, list);
+        }
+
+        // Test adding at the front semantics
+        byte[][] values2 = new byte[][] { Utils.NewGuidByteArray(), Utils.NewGuidByteArray() };
+        concatenateResponse = await client.ListConcatenateBackAsync(cacheName, listName, values2, false);
+        Assert.True(concatenateResponse is CacheListConcatenateBackResponse.Success, $"Unexpected response: {concatenateResponse}");
+        var successResponse = (CacheListConcatenateBackResponse.Success)concatenateResponse;
+        Assert.Equal(4, successResponse.ListLength);
+
+        fetchResponse = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
+        hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
+        list = hitResponse.ByteArrayList!;
+        for (int i = 0; i < values2.Length; i++) {
+            Assert.Equal(values1[i], list[i]);
+        }
+        foreach (byte[] value in values2) {
+            Assert.Contains(value, list);
+        }
+    }
+
+    [Fact]
+    public async Task ListConcatenateBackFetch_ValueIsByteArray_NoRefreshTtl()
+    {
+        var listName = Utils.NewGuidString();
+        byte[][] values = new byte[][] { Utils.NewGuidByteArray() };
+
+        await client.ListConcatenateBackAsync(cacheName, listName, values, false, ttl: TimeSpan.FromSeconds(5));
+        await Task.Delay(100);
+
+        await client.ListConcatenateBackAsync(cacheName, listName, values, false, ttl: TimeSpan.FromSeconds(5));
+        await Task.Delay(4900);
+
+        CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
+    }
+
+    [Fact]
+    public async Task ListConcatenateBackFetch_ValueIsByteArray_RefreshTtl()
+    {
+        var listName = Utils.NewGuidString();
+        byte[][] values = new byte[][] { Utils.NewGuidByteArray() };
+
+        await client.ListConcatenateBackAsync(cacheName, listName, values, false, ttl: TimeSpan.FromSeconds(2));
+        await client.ListConcatenateBackAsync(cacheName, listName, values, true, ttl: TimeSpan.FromSeconds(10));
+        await Task.Delay(2000);
+
+        CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
+        var hitResponse = (CacheListFetchResponse.Hit)response;
+        Assert.Equal(2, hitResponse.ByteArrayList!.Count);
+    }
+
+    [Fact]
+    public async Task ListConcatenateBackAsync_ValueIsByteArrayTruncateFrontoSizeIsZero_IsError()
+    {
+        byte[][] values = new byte[][] { };
+        var response = await client.ListConcatenateBackAsync("myCache", "listName", values, false, truncateFrontToSize: 0);
+        Assert.True(response is CacheListConcatenateBackResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListConcatenateBackResponse.Error)response).ErrorCode);
+    }
+
+    [Fact]
+    public async Task ListConcatenateBackFetch_ValueIsStringArray_HappyPath()
+    {
+        var listName = Utils.NewGuidString();
+        string[] values1 = new string[] { Utils.NewGuidString(), Utils.NewGuidString() };
+
+        CacheListConcatenateBackResponse concatenateResponse = await client.ListConcatenateBackAsync(cacheName, listName, values1, false);
+        Assert.True(concatenateResponse is CacheListConcatenateBackResponse.Success, $"Unexpected response: {concatenateResponse}");
+        Assert.Equal(1, ((CacheListConcatenateBackResponse.Success)concatenateResponse).ListLength);
+
+        CacheListFetchResponse fetchResponse = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
+        var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
+
+        var list = hitResponse.StringList()!;
+        Assert.NotEmpty(list);
+        foreach (string value in values1) {
+            Assert.Contains(value, list);
+        }
+
+        // Test adding at the front semantics
+        string[] values2 = new string[] { Utils.NewGuidString(), Utils.NewGuidString() };
+        concatenateResponse = await client.ListConcatenateBackAsync(cacheName, listName, values2, false);
+        Assert.True(concatenateResponse is CacheListConcatenateBackResponse.Success, $"Unexpected response: {concatenateResponse}");
+        var successResponse = (CacheListConcatenateBackResponse.Success)concatenateResponse;
+        Assert.Equal(4, successResponse.ListLength);
+
+        fetchResponse = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
+        hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
+        list = hitResponse.StringList()!;
+        var values3 = new List<String>(values1);
+        values3.AddRange(values2);
+        Assert.Equal(values3, list);
+    }
+
+    [Fact]
+    public async Task ListConcatenateBackFetch_ValueIsStringArray_NoRefreshTtl()
+    {
+        var listName = Utils.NewGuidString();
+        string[] values = new string[] { Utils.NewGuidString() };
+
+        await client.ListConcatenateBackAsync(cacheName, listName, values, false, ttl: TimeSpan.FromSeconds(5));
+        await Task.Delay(100);
+
+        await client.ListConcatenateBackAsync(cacheName, listName, values, false, ttl: TimeSpan.FromSeconds(5));
+        await Task.Delay(4900);
+
+        CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
+    }
+
+    [Fact]
+    public async Task ListConcatenateBackFetch_ValueIsStringArray_RefreshTtl()
+    {
+        var listName = Utils.NewGuidString();
+        string[] values = new string[] { Utils.NewGuidString() };
+
+        await client.ListConcatenateBackAsync(cacheName, listName, values, false, ttl: TimeSpan.FromSeconds(2));
+        await client.ListConcatenateBackAsync(cacheName, listName, values, true, ttl: TimeSpan.FromSeconds(10));
+        await Task.Delay(2000);
+
+        CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
+        var hitResponse = (CacheListFetchResponse.Hit)response;
+        Assert.Equal(2, hitResponse.ByteArrayList!.Count);
+    }
+
+    [Fact]
+    public async Task ListConcatenateBackAsync_ValueIsStringArrayTruncateBackToSizeIsZero_IsError()
+    {
+        string[] values = new string[] { };
+        var response = await client.ListConcatenateBackAsync("myCache", "listName", values, false, truncateFrontToSize: 0);
+        Assert.True(response is CacheListConcatenateBackResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListConcatenateBackResponse.Error)response).ErrorCode);
+    }
+
+    [Theory]
     [InlineData(null, "my-list", new byte[] { 0x00 })]
     [InlineData("cache", null, new byte[] { 0x00 })]
     [InlineData("cache", "my-list", null)]


### PR DESCRIPTION
Adds two new APIs for List: `ListConcatenateFront` and `ListconcatenateBack`.

Adds new tests for verifying these changes, but these should pass once the necessary service changes
are deployed.
