### PR TITLE
fix: cache dictionary get batch response returning hit errors

### DIFF
--- a/src/Momento.Sdk.Incubating/Responses/CacheDictionaryGetBatchResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheDictionaryGetBatchResponse.cs
@@ -24,7 +24,7 @@ public abstract class CacheDictionaryGetBatchResponse
                 {
                     responsesList.Add(new CacheDictionaryGetResponse.Hit(response.CacheBody));
                 }
-                if (response.Result == ECacheResult.Miss)
+                else if (response.Result == ECacheResult.Miss)
                 {
                     responsesList.Add(new CacheDictionaryGetResponse.Miss());
                 }

--- a/src/Momento.Sdk.Incubating/Responses/CacheDictionaryGetBatchResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheDictionaryGetBatchResponse.cs
@@ -38,7 +38,7 @@ public abstract class CacheDictionaryGetBatchResponse
 
         public Success(int numRequested)
         {
-            Responses = (List<CacheDictionaryGetResponse>)Enumerable.Range(1, numRequested).Select(_ => new CacheDictionaryGetResponse.Miss());
+            Responses = Enumerable.Range(1, numRequested).Select(_ => new CacheDictionaryGetResponse.Miss()).ToList<CacheDictionaryGetResponse>();
         }
 
         public IEnumerable<string?> Strings()

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
@@ -687,6 +687,9 @@ public class DictionaryTest : TestBase
         CacheDictionaryGetBatchResponse response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, new byte[][] { field1, field2, field3 });
         Assert.True(response is CacheDictionaryGetBatchResponse.Success, $"Unexpected response: {response}");
         var nullResponse = (CacheDictionaryGetBatchResponse.Success)response;
+        Assert.True(nullResponse.Responses[0] is CacheDictionaryGetResponse.Miss);
+        Assert.True(nullResponse.Responses[1] is CacheDictionaryGetResponse.Miss);
+        Assert.True(nullResponse.Responses[2] is CacheDictionaryGetResponse.Miss);
         var byteArrays = new byte[]?[] { null, null, null };
         var strings = new string?[] { null, null, null };
 

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
@@ -667,8 +667,13 @@ public class DictionaryTest : TestBase
         CacheDictionaryGetBatchResponse response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, new byte[][] { field1, field2, field3 });
         Assert.True(response is CacheDictionaryGetBatchResponse.Success, $"Unexpected response: {response}");
 
+        var success = (CacheDictionaryGetBatchResponse.Success)response;
+        Assert.Equal(3, success.Responses.Count);
+        Assert.True(success.Responses[0] is CacheDictionaryGetResponse.Hit);
+        Assert.True(success.Responses[1] is CacheDictionaryGetResponse.Hit);
+        Assert.True(success.Responses[2] is CacheDictionaryGetResponse.Miss);
         var values = new byte[]?[] { value1, value2, null };
-        Assert.Equal(values, ((CacheDictionaryGetBatchResponse.Success)response).ByteArrays);
+        Assert.Equal(values, success.ByteArrays);
     }
 
     [Fact]
@@ -737,8 +742,14 @@ public class DictionaryTest : TestBase
 
         CacheDictionaryGetBatchResponse response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, new string[] { field1, field2, field3 });
         Assert.True(response is CacheDictionaryGetBatchResponse.Success, $"Unexpected response: {response}");
+        var success = (CacheDictionaryGetBatchResponse.Success)response;
+
+        Assert.Equal(3, success.Responses.Count);
+        Assert.True(success.Responses[0] is CacheDictionaryGetResponse.Hit);
+        Assert.True(success.Responses[1] is CacheDictionaryGetResponse.Hit);
+        Assert.True(success.Responses[2] is CacheDictionaryGetResponse.Miss);
         var values = new string?[] { value1, value2, null };
-        Assert.Equal(values, ((CacheDictionaryGetBatchResponse.Success)response).Strings());
+        Assert.Equal(values, success.Strings());
     }
 
     [Theory]


### PR DESCRIPTION
Fixes bug in `CacheDictionaryGetBatchResponse` -- the previous version had an `if` instead of `else if`. This corrects the problem and also adds test that would have detected the bug before.

Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/136