### PR TITLE
chore: pascal case CollectionTtl methods

### DIFF
--- a/src/Momento.Sdk.Incubating/Requests/CollectionTtl.cs
+++ b/src/Momento.Sdk.Incubating/Requests/CollectionTtl.cs
@@ -14,7 +14,7 @@ namespace Momento.Sdk.Incubating.Requests
     ///
     /// The default behavior is to refresh the TTL (to prolong the life of the
     /// collection) each time it is written.  This behavior can be modified
-    /// by calling the <see cref="withNoRefreshTtlOnUpdates"/>
+    /// by calling the <see cref="WithNoRefreshTtlOnUpdates"/>
     /// </summary>
     /// 
     /// <param name="Ttl">The TimeSpan after which the cached collection
@@ -32,7 +32,7 @@ namespace Momento.Sdk.Incubating.Requests
         /// time the collection is modified.
         /// </summary>
         /// <returns></returns>
-        public static CollectionTtl fromCacheTtl()
+        public static CollectionTtl FromCacheTtl()
         {
             return new CollectionTtl(Ttl: null, RefreshTtl: true);
         }
@@ -43,7 +43,7 @@ namespace Momento.Sdk.Incubating.Requests
         /// </summary>
         /// <param name="ttl"></param>
         /// <returns></returns>
-        public static CollectionTtl of(TimeSpan ttl)
+        public static CollectionTtl Of(TimeSpan ttl)
         {
             return new CollectionTtl(Ttl: ttl);
         }
@@ -53,7 +53,7 @@ namespace Momento.Sdk.Incubating.Requests
         /// the collection is modified.  (This is the default behavior.)
         /// </summary>
         /// <returns>A copy of this CollectionTtl with the refresh TTL behavior enabled.</returns>
-        public CollectionTtl withRefreshTtlOnUpdates()
+        public CollectionTtl WithRefreshTtlOnUpdates()
         {
             return new CollectionTtl(Ttl: this.Ttl, RefreshTtl: true);
         }
@@ -65,7 +65,7 @@ namespace Momento.Sdk.Incubating.Requests
         /// if you make modifications to the value of the collection.
         /// </summary>
         /// <returns>A copy of this CollectionTtl with the refresh TTL behavior disabled.</returns>
-        public CollectionTtl withNoRefreshTtlOnUpdates()
+        public CollectionTtl WithNoRefreshTtlOnUpdates()
         {
             return new CollectionTtl(Ttl: this.Ttl, RefreshTtl: false);
         }

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
@@ -79,11 +79,11 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidByteArray();
         var value = Utils.NewGuidByteArray();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, CollectionTtl.of(TimeSpan.FromSeconds(5)).withNoRefreshTtlOnUpdates());
+        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
         Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(100);
 
-        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, CollectionTtl.of(TimeSpan.FromSeconds(10)).withNoRefreshTtlOnUpdates());
+        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(4900);
 
@@ -98,9 +98,9 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidByteArray();
         var value = Utils.NewGuidByteArray();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, CollectionTtl.of(TimeSpan.FromSeconds(2)));
+        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(2)));
         Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
-        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, CollectionTtl.of(TimeSpan.FromSeconds(10)));
+        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
         Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(2000);
 
@@ -153,9 +153,9 @@ public class DictionaryTest : TestBase
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidString();
 
-        CacheDictionaryIncrementResponse resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.of(TimeSpan.FromSeconds(2)));
+        CacheDictionaryIncrementResponse resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
         Assert.True(resp is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {resp}");
-        resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)));
+        resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
         Assert.True(resp is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {resp}");
         await Task.Delay(2000);
 
@@ -170,11 +170,11 @@ public class DictionaryTest : TestBase
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidString();
 
-        CacheDictionaryIncrementResponse resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.of(TimeSpan.FromSeconds(5)));
+        CacheDictionaryIncrementResponse resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)));
         Assert.True(resp is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {resp}");
         await Task.Delay(101);
 
-        resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)).withNoRefreshTtlOnUpdates());
+        resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         Assert.True(resp is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {resp}");
         await Task.Delay(4900);
 
@@ -290,11 +290,11 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(5)));
+        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)));
         Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(100);
 
-        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)).withNoRefreshTtlOnUpdates());
+        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(4900);
 
@@ -309,9 +309,9 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(2)));
+        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
         Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
-        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)));
+        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
         Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(2000);
 
@@ -353,11 +353,11 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(5)));
+        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)));
         Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(100);
 
-        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)).withNoRefreshTtlOnUpdates());
+        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(4900);
 
@@ -372,9 +372,9 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(2)));
+        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
         Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
-        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)));
+        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
         Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(2000);
 
@@ -415,7 +415,7 @@ public class DictionaryTest : TestBase
 
         var items = new Dictionary<byte[], byte[]>() { { field1, value1 }, { field2, value2 } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, items, CollectionTtl.of(TimeSpan.FromSeconds(10)));
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, items, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
 
         CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field1);
         Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
@@ -434,10 +434,10 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
         var content = new Dictionary<byte[], byte[]>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.of(TimeSpan.FromSeconds(5)));
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)));
         await Task.Delay(100);
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)).withNoRefreshTtlOnUpdates());
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(4900);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
@@ -452,8 +452,8 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
         var content = new Dictionary<byte[], byte[]>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.of(TimeSpan.FromSeconds(2)));
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)));
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
         await Task.Delay(2000);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
@@ -512,10 +512,10 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidString();
         var content = new Dictionary<string, string>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.of(TimeSpan.FromSeconds(5)));
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)));
         await Task.Delay(100);
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)).withNoRefreshTtlOnUpdates());
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(4900);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
@@ -530,8 +530,8 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidString();
         var content = new Dictionary<string, string>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.of(TimeSpan.FromSeconds(2)));
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)));
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
         await Task.Delay(2000);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
@@ -590,10 +590,10 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
         var content = new Dictionary<string, byte[]>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.of(TimeSpan.FromSeconds(5)).withNoRefreshTtlOnUpdates());
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(100);
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)).withNoRefreshTtlOnUpdates());
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(4900);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
@@ -608,8 +608,8 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
         var content = new Dictionary<string, byte[]>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.of(TimeSpan.FromSeconds(2)));
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)));
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
         await Task.Delay(2000);
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
@@ -61,10 +61,10 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(5)).withNoRefreshTtlOnUpdates());
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(100);
 
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)).withNoRefreshTtlOnUpdates());
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(4900);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -77,8 +77,8 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(2)).withNoRefreshTtlOnUpdates());
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)));
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -146,10 +146,10 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(5)).withNoRefreshTtlOnUpdates());
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(100);
 
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)).withNoRefreshTtlOnUpdates());
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(4900);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -162,8 +162,8 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(2)).withNoRefreshTtlOnUpdates());
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)));
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -231,10 +231,10 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(5)).withNoRefreshTtlOnUpdates());
+        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(100);
 
-        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)).withNoRefreshTtlOnUpdates());
+        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(4900);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -247,8 +247,8 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(2)).withNoRefreshTtlOnUpdates());
-        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)));
+        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
+        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -388,10 +388,10 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(2)).withNoRefreshTtlOnUpdates());
+        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(100);
 
-        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)).withNoRefreshTtlOnUpdates());
+        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(4900);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -404,8 +404,8 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(2)));
-        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)));
+        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
+        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/SetTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/SetTest.cs
@@ -46,11 +46,11 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidByteArray();
 
-        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, ttl: CollectionTtl.of(TimeSpan.FromSeconds(5)).withNoRefreshTtlOnUpdates());
+        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(100);
 
-        response = await client.SetAddAsync(cacheName, setName, element, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)).withNoRefreshTtlOnUpdates());
+        response = await client.SetAddAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(4900);
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
@@ -63,9 +63,9 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidByteArray();
 
-        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, ttl: CollectionTtl.of(TimeSpan.FromSeconds(2)).withNoRefreshTtlOnUpdates());
+        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
-        await client.SetAddAsync(cacheName, setName, element, CollectionTtl.of(TimeSpan.FromSeconds(10)));
+        await client.SetAddAsync(cacheName, setName, element, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
         await Task.Delay(2000);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
@@ -107,11 +107,11 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidString();
 
-        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, ttl: CollectionTtl.of(TimeSpan.FromSeconds(5)).withNoRefreshTtlOnUpdates());
+        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(100);
 
-        response = await client.SetAddAsync(cacheName, setName, element, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)).withNoRefreshTtlOnUpdates());
+        response = await client.SetAddAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(4900);
 
@@ -125,9 +125,9 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidString();
 
-        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, ttl: CollectionTtl.of(TimeSpan.FromSeconds(2)).withNoRefreshTtlOnUpdates());
+        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
-        response = await client.SetAddAsync(cacheName, setName, element, CollectionTtl.of(TimeSpan.FromSeconds(10)));
+        response = await client.SetAddAsync(cacheName, setName, element, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
         Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(2000);
 
@@ -184,11 +184,11 @@ public class SetTest : TestBase
         var element = Utils.NewGuidByteArray();
         var content = new List<byte[]>() { element };
 
-        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, ttl: CollectionTtl.of(TimeSpan.FromSeconds(5)).withNoRefreshTtlOnUpdates());
+        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(100);
 
-        response = await client.SetAddBatchAsync(cacheName, setName, content, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)).withNoRefreshTtlOnUpdates());
+        response = await client.SetAddBatchAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(4900);
 
@@ -203,9 +203,9 @@ public class SetTest : TestBase
         var element = Utils.NewGuidByteArray();
         var content = new List<byte[]>() { element };
 
-        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, ttl: CollectionTtl.of(TimeSpan.FromSeconds(2)).withNoRefreshTtlOnUpdates());
+        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
-        await client.SetAddBatchAsync(cacheName, setName, content, CollectionTtl.of(TimeSpan.FromSeconds(10)));
+        await client.SetAddBatchAsync(cacheName, setName, content, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
         await Task.Delay(2000);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
@@ -264,11 +264,11 @@ public class SetTest : TestBase
         var element = Utils.NewGuidString();
         var content = new List<string>() { element };
 
-        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, ttl: CollectionTtl.of(TimeSpan.FromSeconds(5)).withNoRefreshTtlOnUpdates());
+        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(100);
 
-        response = await client.SetAddBatchAsync(cacheName, setName, content, ttl: CollectionTtl.of(TimeSpan.FromSeconds(10)).withNoRefreshTtlOnUpdates());
+        response = await client.SetAddBatchAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(4900);
 
@@ -283,9 +283,9 @@ public class SetTest : TestBase
         var element = Utils.NewGuidString();
         var content = new List<string>() { element };
 
-        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, ttl: CollectionTtl.of(TimeSpan.FromSeconds(2)).withNoRefreshTtlOnUpdates());
+        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
-        response = await client.SetAddBatchAsync(cacheName, setName, content, CollectionTtl.of(TimeSpan.FromSeconds(10)));
+        response = await client.SetAddBatchAsync(cacheName, setName, content, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
         Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(2000);
 


### PR DESCRIPTION
This PR is a purely style change to `CollectionTtl` methods to
PascalCase them.
