### PR TITLE
chore: add convenienced ttl factory method RefreshTtlIfProvided

### DIFF
--- a/Momento.Sdk.Incubating.sln
+++ b/Momento.Sdk.Incubating.sln
@@ -7,6 +7,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Momento.Sdk.Incubating", "s
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Momento.Sdk.Incubating.Tests.Integration", "tests\Integration\Momento.Sdk.Incubating.Tests\Momento.Sdk.Incubating.Tests.csproj", "{A0F6221C-42A9-454B-BB82-EDB9841DF6E1}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{82AFB43D-C511-4BA0-8E7B-92B5819E7FF9}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Unit", "Unit", "{BF9A055A-D772-41DE-BB04-9BC9098DEE78}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Momento.Sdk.Incubating.Tests", "tests\Unit\Momento.Sdk.Incubating.Tests\Momento.Sdk.Incubating.Tests.csproj", "{27D5EBD6-FFC2-43CC-BE73-7C0858327E0F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,11 +35,19 @@ Global
 		{A0F6221C-42A9-454B-BB82-EDB9841DF6E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A0F6221C-42A9-454B-BB82-EDB9841DF6E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A0F6221C-42A9-454B-BB82-EDB9841DF6E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{27D5EBD6-FFC2-43CC-BE73-7C0858327E0F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{27D5EBD6-FFC2-43CC-BE73-7C0858327E0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{27D5EBD6-FFC2-43CC-BE73-7C0858327E0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{27D5EBD6-FFC2-43CC-BE73-7C0858327E0F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4A2979F2-C61A-493A-9572-26AA07BF7932}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{BF9A055A-D772-41DE-BB04-9BC9098DEE78} = {82AFB43D-C511-4BA0-8E7B-92B5819E7FF9}
+		{27D5EBD6-FFC2-43CC-BE73-7C0858327E0F} = {BF9A055A-D772-41DE-BB04-9BC9098DEE78}
 	EndGlobalSection
 EndGlobal

--- a/src/Momento.Sdk.Incubating/Requests/CollectionTtl.cs
+++ b/src/Momento.Sdk.Incubating/Requests/CollectionTtl.cs
@@ -17,17 +17,17 @@ namespace Momento.Sdk.Incubating.Requests
     /// by calling the <see cref="WithNoRefreshTtlOnUpdates"/>
     /// </summary>
     /// 
-    /// <param name="Ttl">The TimeSpan after which the cached collection
+    /// <param name="Ttl">The <see cref="TimeSpan"/> after which the cached collection
     /// should be expired from the cache.  If <code>null</code>, we use the default
-    /// TTL TimeSpan that was passed to the <see cref="SimpleCacheClient"/>constructor</param>.
-    /// <param name="RefreshTtl">If true, the collection's TTL will be refreshed (to
-    /// prolong the life of the collection) on every update.  If false, the collection's
+    /// TTL <see cref="TimeSpan"/> that was passed to the <see cref="SimpleCacheClient"/>constructor</param>.
+    /// <param name="RefreshTtl">If <see langword="true"/>, the collection's TTL will be refreshed (to
+    /// prolong the life of the collection) on every update.  If <see langword="false"/>, the collection's
     /// TTL will only be set when the collection is initially created.</param>
     public record struct CollectionTtl(TimeSpan? Ttl = null, bool RefreshTtl = true)
     {
         /// <summary>
         /// The default way to handle TTLs for collections.  The default TTL
-        /// TimeSpan that was specified when constructing the <see cref="SimpleCacheClient"/>
+        /// <see cref="TimeSpan"/> that was specified when constructing the <see cref="SimpleCacheClient"/>
         /// will be used, and the TTL for the collection will be refreshed any
         /// time the collection is modified.
         /// </summary>
@@ -38,7 +38,7 @@ namespace Momento.Sdk.Incubating.Requests
         }
 
         /// <summary>
-        /// Constructs a CollectionTtl with the specified TimeSpan.  The TTL
+        /// Constructs a CollectionTtl with the specified <see cref="TimeSpan"/>.  The TTL
         /// for the collection will be refreshed any time the collection is
         /// modified.
         /// </summary>

--- a/src/Momento.Sdk.Incubating/Requests/CollectionTtl.cs
+++ b/src/Momento.Sdk.Incubating/Requests/CollectionTtl.cs
@@ -50,6 +50,17 @@ namespace Momento.Sdk.Incubating.Requests
         }
 
         /// <summary>
+        /// Constructs a <see cref="CollectionTtl"/> with the specified <see cref="TimeSpan"/>.
+        /// Will only refresh if the TTL is provided (ie not <see langword="null" />).
+        /// </summary>
+        /// <param name="ttl"></param>
+        /// <returns></returns>
+        public static CollectionTtl RefreshTtlIfProvided(TimeSpan? ttl = null)
+        {
+            return new CollectionTtl(Ttl: ttl, RefreshTtl: ttl.HasValue);
+        }
+
+        /// <summary>
         /// Specifies that the TTL for the collection should be refreshed when
         /// the collection is modified.  (This is the default behavior.)
         /// </summary>

--- a/src/Momento.Sdk.Incubating/Requests/CollectionTtl.cs
+++ b/src/Momento.Sdk.Incubating/Requests/CollectionTtl.cs
@@ -36,6 +36,7 @@ namespace Momento.Sdk.Incubating.Requests
         {
             return new CollectionTtl(Ttl: null, RefreshTtl: true);
         }
+
         /// <summary>
         /// Constructs a CollectionTtl with the specified TimeSpan.  The TTL
         /// for the collection will be refreshed any time the collection is

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/BatchTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/BatchTest.cs
@@ -6,9 +6,9 @@ using Momento.Sdk.Incubating.Responses;
 using Momento.Sdk.Responses;
 
 [Collection("SimpleCacheClient")]
-public class BatchTests : TestBase
+public class BatchTest : TestBase
 {
-    public BatchTests(SimpleCacheClientFixture fixture) : base(fixture)
+    public BatchTest(SimpleCacheClientFixture fixture) : base(fixture)
     {
     }
 

--- a/tests/Unit/Momento.Sdk.Incubating.Tests/Momento.Sdk.Incubating.Tests.csproj
+++ b/tests/Unit/Momento.Sdk.Incubating.Tests/Momento.Sdk.Incubating.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Momento.Sdk.Incubating\Momento.Sdk.Incubating.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Momento.Sdk.Incubating.Tests/Requests/CollectionTtlTest.cs
+++ b/tests/Unit/Momento.Sdk.Incubating.Tests/Requests/CollectionTtlTest.cs
@@ -80,4 +80,20 @@ public class CollectionTtlTest
         Assert.Null(newCollectionTtl.Ttl);
         Assert.False(newCollectionTtl.RefreshTtl);
     }
+
+    [Fact]
+    public void RefreshTtlIfProvided_NoTtl_DoNotRefresh()
+    {
+        var collectionTtl = CollectionTtl.RefreshTtlIfProvided(null);
+        Assert.False(collectionTtl.RefreshTtl);
+        Assert.Null(collectionTtl.Ttl);
+    }
+
+    [Fact]
+    public void RefreshTtlIfProvided_HasTtl_DoRefresh()
+    {
+        var collectionTtl = CollectionTtl.RefreshTtlIfProvided(TimeSpan.FromDays(1));
+        Assert.True(collectionTtl.RefreshTtl);
+        Assert.Equal(TimeSpan.FromDays(1), collectionTtl.Ttl);
+    }
 }

--- a/tests/Unit/Momento.Sdk.Incubating.Tests/Requests/CollectionTtlTest.cs
+++ b/tests/Unit/Momento.Sdk.Incubating.Tests/Requests/CollectionTtlTest.cs
@@ -1,0 +1,83 @@
+using System;
+using Momento.Sdk.Incubating.Requests;
+
+namespace Momento.Sdk.Incubating.Tests.Requests;
+
+public class CollectionTtlTest
+{
+    [Fact]
+    public void FromCacheTtl_NoArgs_HappyPath()
+    {
+        var collectionTtl = CollectionTtl.FromCacheTtl();
+        Assert.True(collectionTtl.RefreshTtl);
+        Assert.Null(collectionTtl.Ttl);
+    }
+
+    [Fact]
+    public void Of_1DayTtl_HappyPath()
+    {
+        var collectionTtl = CollectionTtl.Of(TimeSpan.FromDays(1));
+        Assert.True(collectionTtl.RefreshTtl, "RefreshTtl should be true but wasn't");
+        Assert.Equal(TimeSpan.FromDays(1), collectionTtl.Ttl);
+    }
+
+    [Fact]
+    public void WithRefreshTtlOnUpdates_OverrideRefresh_HappyPath()
+    {
+        var collectionTtl = new CollectionTtl(null, false);
+        Assert.Null(collectionTtl.Ttl);
+        Assert.False(collectionTtl.RefreshTtl, "RefreshTtl should be false but wasn't");
+
+        var newCollectionTtl = collectionTtl.WithRefreshTtlOnUpdates();
+        Assert.Equal(collectionTtl.Ttl, newCollectionTtl.Ttl);
+        Assert.True(newCollectionTtl.RefreshTtl, "RefreshTtl should be true but wasn't");
+
+        // Test propgates ttl
+        collectionTtl = new CollectionTtl(TimeSpan.FromDays(1), false);
+        Assert.Equal(TimeSpan.FromDays(1), collectionTtl.Ttl);
+        Assert.False(collectionTtl.RefreshTtl, "RefreshTtl should be false but wasn't");
+
+        newCollectionTtl = collectionTtl.WithRefreshTtlOnUpdates();
+        Assert.Equal(collectionTtl.Ttl, newCollectionTtl.Ttl);
+        Assert.True(newCollectionTtl.RefreshTtl, "RefreshTtl should be true but wasn't");
+
+        // Test doesn't change refresh ttl
+        collectionTtl = new CollectionTtl(null, true);
+        Assert.Null(collectionTtl.Ttl);
+        Assert.True(collectionTtl.RefreshTtl, "RefreshTtl should be true but wasn't");
+
+        newCollectionTtl = collectionTtl.WithRefreshTtlOnUpdates();
+        Assert.Null(newCollectionTtl.Ttl);
+        Assert.True(newCollectionTtl.RefreshTtl);
+    }
+
+    [Fact]
+    public void WithNoRefreshTtlOnUpdates_OverrideRefresh_HappyPath()
+    {
+        var collectionTtl = new CollectionTtl(null, true);
+        Assert.Null(collectionTtl.Ttl);
+        Assert.True(collectionTtl.RefreshTtl, "RefreshTtl should be true but wasn't");
+
+        var newCollectionTtl = collectionTtl.WithNoRefreshTtlOnUpdates();
+        Assert.Equal(collectionTtl.Ttl, newCollectionTtl.Ttl);
+        Assert.False(newCollectionTtl.RefreshTtl, "RefreshTtl should be false but wasn't");
+
+        // Test propgates ttl
+        collectionTtl = new CollectionTtl(TimeSpan.FromDays(1), true);
+        Assert.Equal(TimeSpan.FromDays(1), collectionTtl.Ttl);
+        Assert.True(collectionTtl.RefreshTtl, "RefreshTtl should be true but wasn't");
+
+        newCollectionTtl = collectionTtl.WithNoRefreshTtlOnUpdates();
+        Assert.Equal(collectionTtl.Ttl, newCollectionTtl.Ttl);
+        Assert.False(newCollectionTtl.RefreshTtl, "RefreshTtl should be false but wasn't");
+
+        // Test doesn't change refresh ttl
+        collectionTtl = new CollectionTtl(null, false);
+        Assert.Null(collectionTtl.Ttl);
+        Assert.False(collectionTtl.RefreshTtl, "RefreshTtl should be false but wasn't");
+
+        newCollectionTtl = collectionTtl.WithNoRefreshTtlOnUpdates();
+        Assert.Null(newCollectionTtl.Ttl);
+        Assert.False(newCollectionTtl.RefreshTtl);
+    }
+}

--- a/tests/Unit/Momento.Sdk.Incubating.Tests/Usings.cs
+++ b/tests/Unit/Momento.Sdk.Incubating.Tests/Usings.cs
@@ -1,0 +1,2 @@
+global using Momento.Sdk.Incubating;
+global using Xunit;


### PR DESCRIPTION
This PR adds a new `CollectionTtl` factory method to refresh the ttl if-and-only-if the provided TTL is not null. We also backfill unit test.
