### PR TITLE
chore: make all value accessors be properties and pre-fix with `.Value`

### DIFF
--- a/src/Momento.Sdk.Incubating/Momento.Sdk.Incubating.csproj
+++ b/src/Momento.Sdk.Incubating/Momento.Sdk.Incubating.csproj
@@ -34,7 +34,7 @@
 		<RepositoryUrl>https://github.com/momentohq/client-sdk-dotnet-incubating</RepositoryUrl>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Momento.Sdk" Version="0.38.1" />
+		<PackageReference Include="Momento.Sdk" Version="1.0.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/src/Momento.Sdk.Incubating/Responses/CacheDictionaryFetchResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheDictionaryFetchResponse.cs
@@ -40,11 +40,11 @@ public abstract class CacheDictionaryFetchResponse
             });
         }
 
-        public Dictionary<byte[], byte[]> ValueByteArrayByteArrayDictionary { get => _byteArrayByteArrayDictionary.Value; }
+        public Dictionary<byte[], byte[]> ValueDictionaryByteArrayByteArray { get => _byteArrayByteArrayDictionary.Value; }
 
-        public Dictionary<string, string> ValueStringStringDictionary { get => _stringStringDictionary.Value; }
+        public Dictionary<string, string> ValueDictionaryStringString { get => _stringStringDictionary.Value; }
 
-        public Dictionary<string, byte[]> ValueStringByteArrayDictionary { get => _stringByteArrayDictionary.Value; }
+        public Dictionary<string, byte[]> ValueDictionaryStringByteArray { get => _stringByteArrayDictionary.Value; }
     }
 
     public class Miss : CacheDictionaryFetchResponse

--- a/src/Momento.Sdk.Incubating/Responses/CacheDictionaryFetchResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheDictionaryFetchResponse.cs
@@ -40,11 +40,11 @@ public abstract class CacheDictionaryFetchResponse
             });
         }
 
-        public Dictionary<byte[], byte[]> ByteArrayByteArrayDictionary { get => _byteArrayByteArrayDictionary.Value; }
+        public Dictionary<byte[], byte[]> ValueByteArrayByteArrayDictionary { get => _byteArrayByteArrayDictionary.Value; }
 
-        public Dictionary<string, string> StringStringDictionary() => _stringStringDictionary.Value;
+        public Dictionary<string, string> ValueStringStringDictionary { get => _stringStringDictionary.Value; }
 
-        public Dictionary<string, byte[]> StringByteArrayDictionary() => _stringByteArrayDictionary.Value;
+        public Dictionary<string, byte[]> ValueStringByteArrayDictionary { get => _stringByteArrayDictionary.Value; }
     }
 
     public class Miss : CacheDictionaryFetchResponse

--- a/src/Momento.Sdk.Incubating/Responses/CacheDictionaryGetBatchResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheDictionaryGetBatchResponse.cs
@@ -50,7 +50,7 @@ public abstract class CacheDictionaryGetBatchResponse
                 {
                     if (response is CacheDictionaryGetResponse.Hit hitResponse)
                     {
-                        ret.Add(hitResponse.String());
+                        ret.Add(hitResponse.ValueString);
                     }
                     else if (response is CacheDictionaryGetResponse.Miss missResponse)
                     {
@@ -70,7 +70,7 @@ public abstract class CacheDictionaryGetBatchResponse
                 {
                     if (response is CacheDictionaryGetResponse.Hit hitResponse)
                     {
-                        ret.Add(hitResponse.ByteArray);
+                        ret.Add(hitResponse.ValueByteArray);
                     }
                     else if (response is CacheDictionaryGetResponse.Miss missResponse)
                     {

--- a/src/Momento.Sdk.Incubating/Responses/CacheDictionaryGetBatchResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheDictionaryGetBatchResponse.cs
@@ -41,24 +41,27 @@ public abstract class CacheDictionaryGetBatchResponse
             Responses = Enumerable.Range(1, numRequested).Select(_ => new CacheDictionaryGetResponse.Miss()).ToList<CacheDictionaryGetResponse>();
         }
 
-        public IEnumerable<string?> Strings()
+        public IEnumerable<string?> ValueStrings
         {
-            var ret = new List<string?>();
-            foreach (CacheDictionaryGetResponse response in Responses)
+            get
             {
-                if (response is CacheDictionaryGetResponse.Hit hitResponse)
+                var ret = new List<string?>();
+                foreach (CacheDictionaryGetResponse response in Responses)
                 {
-                    ret.Add(hitResponse.String());
+                    if (response is CacheDictionaryGetResponse.Hit hitResponse)
+                    {
+                        ret.Add(hitResponse.String());
+                    }
+                    else if (response is CacheDictionaryGetResponse.Miss missResponse)
+                    {
+                        ret.Add(null);
+                    }
                 }
-                else if (response is CacheDictionaryGetResponse.Miss missResponse)
-                {
-                    ret.Add(null);
-                }
+                return ret.ToArray();
             }
-            return ret.ToArray();
         }
 
-        public IEnumerable<byte[]?> ByteArrays
+        public IEnumerable<byte[]?> ValueByteArrays
         {
             get
             {

--- a/src/Momento.Sdk.Incubating/Responses/CacheDictionaryGetResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheDictionaryGetResponse.cs
@@ -22,12 +22,12 @@ public abstract class CacheDictionaryGetResponse
             this.value = cacheBody;
         }
 
-        public byte[] ByteArray
+        public byte[] ValueByteArray
         {
             get => value.ToByteArray();
         }
 
-        public string String() => value.ToStringUtf8();
+        public string ValueString { get => value.ToStringUtf8(); }
     }
 
     public class Miss : CacheDictionaryGetResponse

--- a/src/Momento.Sdk.Incubating/Responses/CacheGetBatchResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheGetBatchResponse.cs
@@ -15,24 +15,27 @@ public abstract class CacheGetBatchResponse
             this.Responses = new(responses);
         }
 
-        public IEnumerable<string?> Strings()
+        public IEnumerable<string?> ValueStrings
         {
-            var ret = new List<string?>();
-            foreach (CacheGetResponse response in Responses)
+            get
             {
-                if (response is CacheGetResponse.Hit hitResponse)
+                var ret = new List<string?>();
+                foreach (CacheGetResponse response in Responses)
                 {
-                    ret.Add(hitResponse.ValueString);
+                    if (response is CacheGetResponse.Hit hitResponse)
+                    {
+                        ret.Add(hitResponse.ValueString);
+                    }
+                    else if (response is CacheGetResponse.Miss missResponse)
+                    {
+                        ret.Add(null);
+                    }
                 }
-                else if (response is CacheGetResponse.Miss missResponse)
-                {
-                    ret.Add(null);
-                }
+                return ret.ToArray();
             }
-            return ret.ToArray();
         }
 
-        public IEnumerable<byte[]?> ByteArrays
+        public IEnumerable<byte[]?> ValueByteArrays
         {
             get
             {

--- a/src/Momento.Sdk.Incubating/Responses/CacheListFetchResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheListFetchResponse.cs
@@ -31,9 +31,9 @@ public abstract class CacheListFetchResponse
             });
         }
 
-        public List<byte[]> ValueByteArrayList { get => _byteArrayList.Value; }
+        public List<byte[]> ValueListByteArray { get => _byteArrayList.Value; }
 
-        public List<string> ValueStringList { get => _stringList.Value; }
+        public List<string> ValueListString { get => _stringList.Value; }
     }
 
     public class Miss : CacheListFetchResponse

--- a/src/Momento.Sdk.Incubating/Responses/CacheListFetchResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheListFetchResponse.cs
@@ -31,9 +31,9 @@ public abstract class CacheListFetchResponse
             });
         }
 
-        public List<byte[]> ByteArrayList { get => _byteArrayList.Value; }
+        public List<byte[]> ValueByteArrayList { get => _byteArrayList.Value; }
 
-        public List<string> StringList() => _stringList.Value;
+        public List<string> ValueStringList { get => _stringList.Value; }
     }
 
     public class Miss : CacheListFetchResponse

--- a/src/Momento.Sdk.Incubating/Responses/CacheListPopBackResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheListPopBackResponse.cs
@@ -16,12 +16,12 @@ public abstract class CacheListPopBackResponse
             this.value = response.Found.Back;
         }
 
-        public byte[] ByteArray
+        public byte[] ValueByteArray
         {
             get => value.ToByteArray();
         }
 
-        public string String() => value.ToStringUtf8();
+        public string ValueString { get => value.ToStringUtf8(); }
     }
 
     public class Miss : CacheListPopBackResponse

--- a/src/Momento.Sdk.Incubating/Responses/CacheListPopFrontResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheListPopFrontResponse.cs
@@ -17,12 +17,12 @@ public abstract class CacheListPopFrontResponse
             this.value = response.Found.Front;
         }
 
-        public byte[] ByteArray
+        public byte[] ValueByteArray
         {
             get => value.ToByteArray();
         }
 
-        public string String() => value.ToStringUtf8();
+        public string ValueString { get => value.ToStringUtf8(); }
     }
 
     public class Miss : CacheListPopFrontResponse

--- a/src/Momento.Sdk.Incubating/Responses/CacheSetFetchResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheSetFetchResponse.cs
@@ -36,9 +36,9 @@ public abstract class CacheSetFetchResponse
             });
         }
 
-        public HashSet<byte[]> ValueByteArraySet { get => _byteArraySet.Value; }
+        public HashSet<byte[]> ValueSetByteArray { get => _byteArraySet.Value; }
 
-        public HashSet<string> ValueStringSet { get => _stringSet.Value; }
+        public HashSet<string> ValueSetString { get => _stringSet.Value; }
     }
 
     public class Miss : CacheSetFetchResponse

--- a/src/Momento.Sdk.Incubating/Responses/CacheSetFetchResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheSetFetchResponse.cs
@@ -36,9 +36,9 @@ public abstract class CacheSetFetchResponse
             });
         }
 
-        public HashSet<byte[]> ByteArraySet { get => _byteArraySet.Value; }
+        public HashSet<byte[]> ValueByteArraySet { get => _byteArraySet.Value; }
 
-        public HashSet<string> StringSet() => _stringSet.Value;
+        public HashSet<string> ValueStringSet { get => _stringSet.Value; }
     }
 
     public class Miss : CacheSetFetchResponse

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/BatchTests.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/BatchTests.cs
@@ -44,8 +44,8 @@ public class BatchTests : TestBase
         CacheGetBatchResponse result = await client.GetBatchAsync(cacheName, keys);
         Assert.True(result is CacheGetBatchResponse.Success, $"Unexpected response: {result}");
         var goodResult = (CacheGetBatchResponse.Success)result;
-        string? stringResult1 = goodResult.Strings().ToList()[0];
-        string? stringResult2 = goodResult.Strings().ToList()[1];
+        string? stringResult1 = goodResult.ValueStrings.ToList()[0];
+        string? stringResult2 = goodResult.ValueStrings.ToList()[1];
         Assert.Equal(value1, stringResult1);
         Assert.Equal(value2, stringResult2);
     }
@@ -82,7 +82,7 @@ public class BatchTests : TestBase
         CacheGetBatchResponse result = await client.GetBatchAsync(cacheName, keys);
         Assert.True(result is CacheGetBatchResponse.Success, $"Unexpected response: {result}");
         var goodResult = (CacheGetBatchResponse.Success)result;
-        Assert.Equal(goodResult.Strings(), new string[] { value1, value2, null! });
+        Assert.Equal(goodResult.ValueStrings, new string[] { value1, value2, null! });
         Assert.True(goodResult.Responses[0] is CacheGetResponse.Hit);
         Assert.True(goodResult.Responses[1] is CacheGetResponse.Hit);
         Assert.True(goodResult.Responses[2] is CacheGetResponse.Miss);

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
@@ -793,10 +793,10 @@ public class DictionaryTest : TestBase
 
         Assert.True(fetchResponse is CacheDictionaryFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheDictionaryFetchResponse.Hit)fetchResponse;
-        Assert.Equal(hitResponse.ValueStringStringDictionary, contentDictionary);
+        Assert.Equal(hitResponse.ValueDictionaryStringString, contentDictionary);
 
         // Test field caching behavior
-        Assert.Same(hitResponse.ValueStringStringDictionary, hitResponse.ValueStringStringDictionary);
+        Assert.Same(hitResponse.ValueDictionaryStringString, hitResponse.ValueDictionaryStringString);
     }
 
     [Fact]
@@ -819,10 +819,10 @@ public class DictionaryTest : TestBase
 
         Assert.True(fetchResponse is CacheDictionaryFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheDictionaryFetchResponse.Hit)fetchResponse;
-        Assert.Equal(hitResponse.ValueStringByteArrayDictionary, contentDictionary);
+        Assert.Equal(hitResponse.ValueDictionaryStringByteArray, contentDictionary);
 
         // Test field caching behavior
-        Assert.Same(hitResponse.ValueStringByteArrayDictionary, hitResponse.ValueStringByteArrayDictionary);
+        Assert.Same(hitResponse.ValueDictionaryStringByteArray, hitResponse.ValueDictionaryStringByteArray);
     }
 
     [Fact]
@@ -847,15 +847,15 @@ public class DictionaryTest : TestBase
 
         var hitResponse = (CacheDictionaryFetchResponse.Hit)fetchResponse;
         // Exercise byte array dictionary structural equality comparer
-        Assert.True(hitResponse.ValueByteArrayByteArrayDictionary!.ContainsKey(field1));
-        Assert.True(hitResponse.ValueByteArrayByteArrayDictionary!.ContainsKey(field2));
-        Assert.Equal(2, hitResponse.ValueByteArrayByteArrayDictionary!.Count);
+        Assert.True(hitResponse.ValueDictionaryByteArrayByteArray!.ContainsKey(field1));
+        Assert.True(hitResponse.ValueDictionaryByteArrayByteArray!.ContainsKey(field2));
+        Assert.Equal(2, hitResponse.ValueDictionaryByteArrayByteArray!.Count);
 
         // Exercise DictionaryEquals extension
-        Assert.True(hitResponse.ValueByteArrayByteArrayDictionary!.DictionaryEquals(contentDictionary));
+        Assert.True(hitResponse.ValueDictionaryByteArrayByteArray!.DictionaryEquals(contentDictionary));
 
         // Test field caching behavior
-        Assert.Same(hitResponse.ValueByteArrayByteArrayDictionary, hitResponse.ValueByteArrayByteArrayDictionary);
+        Assert.Same(hitResponse.ValueDictionaryByteArrayByteArray, hitResponse.ValueDictionaryByteArrayByteArray);
     }
 
     [Theory]

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
@@ -106,7 +106,7 @@ public class DictionaryTest : TestBase
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
-        Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).ByteArray);
+        Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).ValueByteArray);
     }
 
     [Theory]
@@ -144,7 +144,7 @@ public class DictionaryTest : TestBase
         CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, fieldName);
         Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
         var hitResponse = (CacheDictionaryGetResponse.Hit)getResponse;
-        Assert.Equal("-1000", hitResponse.String());
+        Assert.Equal("-1000", hitResponse.ValueString);
     }
 
     [Fact]
@@ -161,7 +161,7 @@ public class DictionaryTest : TestBase
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
-        Assert.Equal("2", ((CacheDictionaryGetResponse.Hit)response).String());
+        Assert.Equal("2", ((CacheDictionaryGetResponse.Hit)response).ValueString);
     }
 
     [Fact]
@@ -317,7 +317,7 @@ public class DictionaryTest : TestBase
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
-        Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).String());
+        Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).ValueString);
     }
 
     [Theory]
@@ -380,7 +380,7 @@ public class DictionaryTest : TestBase
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
-        Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).ByteArray);
+        Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).ValueByteArray);
     }
 
     [Fact]
@@ -419,11 +419,11 @@ public class DictionaryTest : TestBase
 
         CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field1);
         Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
-        Assert.Equal(value1, ((CacheDictionaryGetResponse.Hit)getResponse).ByteArray);
+        Assert.Equal(value1, ((CacheDictionaryGetResponse.Hit)getResponse).ValueByteArray);
 
         getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field2);
         Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
-        Assert.Equal(value2, ((CacheDictionaryGetResponse.Hit)getResponse).ByteArray);
+        Assert.Equal(value2, ((CacheDictionaryGetResponse.Hit)getResponse).ValueByteArray);
     }
 
     [Fact]
@@ -458,7 +458,7 @@ public class DictionaryTest : TestBase
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
-        Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).ByteArray);
+        Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).ValueByteArray);
     }
 
     [Fact]
@@ -497,11 +497,11 @@ public class DictionaryTest : TestBase
 
         CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field1);
         Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
-        Assert.Equal(value1, ((CacheDictionaryGetResponse.Hit)getResponse).String());
+        Assert.Equal(value1, ((CacheDictionaryGetResponse.Hit)getResponse).ValueString);
 
         getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field2);
         Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
-        Assert.Equal(value2, ((CacheDictionaryGetResponse.Hit)getResponse).String());
+        Assert.Equal(value2, ((CacheDictionaryGetResponse.Hit)getResponse).ValueString);
     }
 
     [Fact]
@@ -536,7 +536,7 @@ public class DictionaryTest : TestBase
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
-        Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).String());
+        Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).ValueString);
     }
 
     [Fact]
@@ -575,11 +575,11 @@ public class DictionaryTest : TestBase
 
         CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field1);
         Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
-        Assert.Equal(value1, ((CacheDictionaryGetResponse.Hit)getResponse).ByteArray);
+        Assert.Equal(value1, ((CacheDictionaryGetResponse.Hit)getResponse).ValueByteArray);
 
         getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field2);
         Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
-        Assert.Equal(value2, ((CacheDictionaryGetResponse.Hit)getResponse).ByteArray);
+        Assert.Equal(value2, ((CacheDictionaryGetResponse.Hit)getResponse).ValueByteArray);
     }
 
     [Fact]
@@ -614,7 +614,7 @@ public class DictionaryTest : TestBase
 
         CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
-        Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).ByteArray);
+        Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).ValueByteArray);
     }
 
     [Fact]
@@ -673,7 +673,7 @@ public class DictionaryTest : TestBase
         Assert.True(success.Responses[1] is CacheDictionaryGetResponse.Hit);
         Assert.True(success.Responses[2] is CacheDictionaryGetResponse.Miss);
         var values = new byte[]?[] { value1, value2, null };
-        Assert.Equal(values, success.ByteArrays);
+        Assert.Equal(values, success.ValueByteArrays);
     }
 
     [Fact]
@@ -693,8 +693,8 @@ public class DictionaryTest : TestBase
         var byteArrays = new byte[]?[] { null, null, null };
         var strings = new string?[] { null, null, null };
 
-        Assert.Equal(byteArrays, nullResponse.ByteArrays);
-        Assert.Equal(strings, nullResponse.Strings()!);
+        Assert.Equal(byteArrays, nullResponse.ValueByteArrays);
+        Assert.Equal(strings, nullResponse.ValueStrings!);
     }
 
     [Fact]
@@ -752,7 +752,7 @@ public class DictionaryTest : TestBase
         Assert.True(success.Responses[1] is CacheDictionaryGetResponse.Hit);
         Assert.True(success.Responses[2] is CacheDictionaryGetResponse.Miss);
         var values = new string?[] { value1, value2, null };
-        Assert.Equal(values, success.Strings());
+        Assert.Equal(values, success.ValueStrings);
     }
 
     [Theory]
@@ -793,10 +793,10 @@ public class DictionaryTest : TestBase
 
         Assert.True(fetchResponse is CacheDictionaryFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheDictionaryFetchResponse.Hit)fetchResponse;
-        Assert.Equal(hitResponse.StringStringDictionary(), contentDictionary);
+        Assert.Equal(hitResponse.ValueStringStringDictionary, contentDictionary);
 
         // Test field caching behavior
-        Assert.Same(hitResponse.StringStringDictionary(), hitResponse.StringStringDictionary());
+        Assert.Same(hitResponse.ValueStringStringDictionary, hitResponse.ValueStringStringDictionary);
     }
 
     [Fact]
@@ -819,10 +819,10 @@ public class DictionaryTest : TestBase
 
         Assert.True(fetchResponse is CacheDictionaryFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheDictionaryFetchResponse.Hit)fetchResponse;
-        Assert.Equal(hitResponse.StringByteArrayDictionary(), contentDictionary);
+        Assert.Equal(hitResponse.ValueStringByteArrayDictionary, contentDictionary);
 
         // Test field caching behavior
-        Assert.Same(hitResponse.StringByteArrayDictionary(), hitResponse.StringByteArrayDictionary());
+        Assert.Same(hitResponse.ValueStringByteArrayDictionary, hitResponse.ValueStringByteArrayDictionary);
     }
 
     [Fact]
@@ -847,15 +847,15 @@ public class DictionaryTest : TestBase
 
         var hitResponse = (CacheDictionaryFetchResponse.Hit)fetchResponse;
         // Exercise byte array dictionary structural equality comparer
-        Assert.True(hitResponse.ByteArrayByteArrayDictionary!.ContainsKey(field1));
-        Assert.True(hitResponse.ByteArrayByteArrayDictionary!.ContainsKey(field2));
-        Assert.Equal(2, hitResponse.ByteArrayByteArrayDictionary!.Count);
+        Assert.True(hitResponse.ValueByteArrayByteArrayDictionary!.ContainsKey(field1));
+        Assert.True(hitResponse.ValueByteArrayByteArrayDictionary!.ContainsKey(field2));
+        Assert.Equal(2, hitResponse.ValueByteArrayByteArrayDictionary!.Count);
 
         // Exercise DictionaryEquals extension
-        Assert.True(hitResponse.ByteArrayByteArrayDictionary!.DictionaryEquals(contentDictionary));
+        Assert.True(hitResponse.ValueByteArrayByteArrayDictionary!.DictionaryEquals(contentDictionary));
 
         // Test field caching behavior
-        Assert.Same(hitResponse.ByteArrayByteArrayDictionary, hitResponse.ByteArrayByteArrayDictionary);
+        Assert.Same(hitResponse.ValueByteArrayByteArrayDictionary, hitResponse.ValueByteArrayByteArrayDictionary);
     }
 
     [Theory]

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
@@ -36,7 +36,7 @@ public class ListTest : TestBase
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
 
-        var list = hitResponse.ByteArrayList;
+        var list = hitResponse.ValueByteArrayList;
         Assert.Single(list);
         Assert.Contains(value1, list);
 
@@ -50,7 +50,7 @@ public class ListTest : TestBase
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
-        list = hitResponse.ByteArrayList!;
+        list = hitResponse.ValueByteArrayList!;
         Assert.Equal(value2, list[0]);
         Assert.Equal(value1, list[1]);
     }
@@ -84,7 +84,7 @@ public class ListTest : TestBase
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
-        Assert.Equal(2, hitResponse.ByteArrayList!.Count);
+        Assert.Equal(2, hitResponse.ValueByteArrayList!.Count);
     }
 
     [Fact]
@@ -121,7 +121,7 @@ public class ListTest : TestBase
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
 
-        var list = hitResponse.StringList();
+        var list = hitResponse.ValueStringList;
         Assert.Single(list);
         Assert.Contains(value1, list);
 
@@ -135,7 +135,7 @@ public class ListTest : TestBase
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
-        list = hitResponse.StringList()!;
+        list = hitResponse.ValueStringList!;
         Assert.Equal(value2, list[0]);
         Assert.Equal(value1, list[1]);
     }
@@ -169,7 +169,7 @@ public class ListTest : TestBase
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
-        Assert.Equal(2, hitResponse.StringList()!.Count);
+        Assert.Equal(2, hitResponse.ValueStringList!.Count);
     }
 
     [Fact]
@@ -206,7 +206,7 @@ public class ListTest : TestBase
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
 
-        var list = hitResponse.ByteArrayList;
+        var list = hitResponse.ValueByteArrayList;
         Assert.Single(list);
         Assert.Contains(value1, list);
 
@@ -220,7 +220,7 @@ public class ListTest : TestBase
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
-        list = hitResponse.ByteArrayList!;
+        list = hitResponse.ValueByteArrayList!;
         Assert.Equal(value1, list[0]);
         Assert.Equal(value2, list[1]);
     }
@@ -254,7 +254,7 @@ public class ListTest : TestBase
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
-        Assert.Equal(2, hitResponse.ByteArrayList!.Count);
+        Assert.Equal(2, hitResponse.ValueByteArrayList!.Count);
     }
 
     [Fact]
@@ -289,9 +289,9 @@ public class ListTest : TestBase
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
-        Assert.Equal(2, hitResponse.StringList()!.Count);
-        Assert.Equal(value2, hitResponse.StringList()![0]);
-        Assert.Equal(value3, hitResponse.StringList()![1]);
+        Assert.Equal(2, hitResponse.ValueStringList!.Count);
+        Assert.Equal(value2, hitResponse.ValueStringList![0]);
+        Assert.Equal(value3, hitResponse.ValueStringList![1]);
     }
 
     [Fact]
@@ -307,9 +307,9 @@ public class ListTest : TestBase
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
-        Assert.Equal(2, hitResponse.ByteArrayList!.Count);
-        Assert.Equal(value2, hitResponse.ByteArrayList![0]);
-        Assert.Equal(value3, hitResponse.ByteArrayList![1]);
+        Assert.Equal(2, hitResponse.ValueByteArrayList!.Count);
+        Assert.Equal(value2, hitResponse.ValueByteArrayList![0]);
+        Assert.Equal(value3, hitResponse.ValueByteArrayList![1]);
     }
 
     [Fact]
@@ -325,9 +325,9 @@ public class ListTest : TestBase
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
-        Assert.Equal(2, hitResponse.StringList()!.Count);
-        Assert.Equal(value2, hitResponse.StringList()![1]);
-        Assert.Equal(value3, hitResponse.StringList()![0]);
+        Assert.Equal(2, hitResponse.ValueStringList!.Count);
+        Assert.Equal(value2, hitResponse.ValueStringList![1]);
+        Assert.Equal(value3, hitResponse.ValueStringList![0]);
     }
 
     [Fact]
@@ -343,9 +343,9 @@ public class ListTest : TestBase
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
-        Assert.Equal(2, hitResponse.ByteArrayList!.Count);
-        Assert.Equal(value2, hitResponse.ByteArrayList![1]);
-        Assert.Equal(value3, hitResponse.ByteArrayList![0]);
+        Assert.Equal(2, hitResponse.ValueByteArrayList!.Count);
+        Assert.Equal(value2, hitResponse.ValueByteArrayList![1]);
+        Assert.Equal(value3, hitResponse.ValueByteArrayList![0]);
     }
 
     [Fact]
@@ -363,7 +363,7 @@ public class ListTest : TestBase
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
 
-        var list = hitResponse.StringList();
+        var list = hitResponse.ValueStringList;
         Assert.Single(list);
         Assert.Contains(value1, list);
 
@@ -377,7 +377,7 @@ public class ListTest : TestBase
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
-        list = hitResponse.StringList()!;
+        list = hitResponse.ValueStringList!;
         Assert.Equal(value1, list[0]);
         Assert.Equal(value2, list[1]);
     }
@@ -411,7 +411,7 @@ public class ListTest : TestBase
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
-        Assert.Equal(2, hitResponse.StringList()!.Count);
+        Assert.Equal(2, hitResponse.ValueStringList!.Count);
     }
 
     [Fact]
@@ -453,7 +453,7 @@ public class ListTest : TestBase
         Assert.True(response is CacheListPopFrontResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListPopFrontResponse.Hit)response;
 
-        Assert.Equal(value2, hitResponse.ByteArray);
+        Assert.Equal(value2, hitResponse.ValueByteArray);
     }
 
     [Fact]
@@ -469,7 +469,7 @@ public class ListTest : TestBase
         Assert.True(response is CacheListPopFrontResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListPopFrontResponse.Hit)response;
 
-        Assert.Equal(value2, hitResponse.String());
+        Assert.Equal(value2, hitResponse.ValueString);
     }
 
     [Theory]
@@ -503,7 +503,7 @@ public class ListTest : TestBase
         Assert.True(response is CacheListPopBackResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListPopBackResponse.Hit)response;
 
-        Assert.Equal(value2, hitResponse.ByteArray);
+        Assert.Equal(value2, hitResponse.ValueByteArray);
     }
 
     [Fact]
@@ -519,7 +519,7 @@ public class ListTest : TestBase
         Assert.True(response is CacheListPopBackResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListPopBackResponse.Hit)response;
 
-        Assert.Equal(value2, hitResponse.String());
+        Assert.Equal(value2, hitResponse.ValueString);
     }
 
     [Theory]
@@ -555,7 +555,7 @@ public class ListTest : TestBase
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
 
-        Assert.Equal(hitResponse.StringList(), contentList);
+        Assert.Equal(hitResponse.ValueStringList, contentList);
     }
 
     [Fact]
@@ -573,9 +573,9 @@ public class ListTest : TestBase
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
 
-        Assert.Contains(field1, hitResponse.ByteArrayList!);
-        Assert.Contains(field2, hitResponse.ByteArrayList!);
-        Assert.Equal(2, hitResponse.ByteArrayList!.Count);
+        Assert.Contains(field1, hitResponse.ValueByteArrayList!);
+        Assert.Contains(field2, hitResponse.ValueByteArrayList!);
+        Assert.Equal(2, hitResponse.ValueByteArrayList!.Count);
     }
 
     [Theory]
@@ -611,7 +611,7 @@ public class ListTest : TestBase
         // Test not there
         var response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
-        var cachedList = ((CacheListFetchResponse.Hit)response).ByteArrayList!;
+        var cachedList = ((CacheListFetchResponse.Hit)response).ValueByteArrayList!;
         Assert.True(list.ListEquals(cachedList));
     }
 
@@ -630,7 +630,7 @@ public class ListTest : TestBase
 
         var response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
-        var cachedList = ((CacheListFetchResponse.Hit)response).ByteArrayList!;
+        var cachedList = ((CacheListFetchResponse.Hit)response).ValueByteArrayList!;
         Assert.True(list.ListEquals(cachedList));
     }
 
@@ -676,7 +676,7 @@ public class ListTest : TestBase
         // Test not there
         var response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
-        var cachedList = ((CacheListFetchResponse.Hit)response).StringList()!;
+        var cachedList = ((CacheListFetchResponse.Hit)response).ValueStringList!;
         Assert.True(list.SequenceEqual(cachedList));
     }
 
@@ -695,7 +695,7 @@ public class ListTest : TestBase
 
         var response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
-        var cachedList = ((CacheListFetchResponse.Hit)response).StringList()!;
+        var cachedList = ((CacheListFetchResponse.Hit)response).ValueStringList!;
         Assert.True(list.SequenceEqual(cachedList));
     }
 

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
@@ -36,7 +36,7 @@ public class ListTest : TestBase
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
 
-        var list = hitResponse.ValueByteArrayList;
+        var list = hitResponse.ValueListByteArray;
         Assert.Single(list);
         Assert.Contains(value1, list);
 
@@ -50,7 +50,7 @@ public class ListTest : TestBase
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
-        list = hitResponse.ValueByteArrayList!;
+        list = hitResponse.ValueListByteArray!;
         Assert.Equal(value2, list[0]);
         Assert.Equal(value1, list[1]);
     }
@@ -84,7 +84,7 @@ public class ListTest : TestBase
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
-        Assert.Equal(2, hitResponse.ValueByteArrayList!.Count);
+        Assert.Equal(2, hitResponse.ValueListByteArray!.Count);
     }
 
     [Fact]
@@ -121,7 +121,7 @@ public class ListTest : TestBase
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
 
-        var list = hitResponse.ValueStringList;
+        var list = hitResponse.ValueListString;
         Assert.Single(list);
         Assert.Contains(value1, list);
 
@@ -135,7 +135,7 @@ public class ListTest : TestBase
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
-        list = hitResponse.ValueStringList!;
+        list = hitResponse.ValueListString!;
         Assert.Equal(value2, list[0]);
         Assert.Equal(value1, list[1]);
     }
@@ -169,7 +169,7 @@ public class ListTest : TestBase
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
-        Assert.Equal(2, hitResponse.ValueStringList!.Count);
+        Assert.Equal(2, hitResponse.ValueListString!.Count);
     }
 
     [Fact]
@@ -206,7 +206,7 @@ public class ListTest : TestBase
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
 
-        var list = hitResponse.ValueByteArrayList;
+        var list = hitResponse.ValueListByteArray;
         Assert.Single(list);
         Assert.Contains(value1, list);
 
@@ -220,7 +220,7 @@ public class ListTest : TestBase
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
-        list = hitResponse.ValueByteArrayList!;
+        list = hitResponse.ValueListByteArray!;
         Assert.Equal(value1, list[0]);
         Assert.Equal(value2, list[1]);
     }
@@ -254,7 +254,7 @@ public class ListTest : TestBase
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
-        Assert.Equal(2, hitResponse.ValueByteArrayList!.Count);
+        Assert.Equal(2, hitResponse.ValueListByteArray!.Count);
     }
 
     [Fact]
@@ -289,9 +289,9 @@ public class ListTest : TestBase
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
-        Assert.Equal(2, hitResponse.ValueStringList!.Count);
-        Assert.Equal(value2, hitResponse.ValueStringList![0]);
-        Assert.Equal(value3, hitResponse.ValueStringList![1]);
+        Assert.Equal(2, hitResponse.ValueListString!.Count);
+        Assert.Equal(value2, hitResponse.ValueListString![0]);
+        Assert.Equal(value3, hitResponse.ValueListString![1]);
     }
 
     [Fact]
@@ -307,9 +307,9 @@ public class ListTest : TestBase
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
-        Assert.Equal(2, hitResponse.ValueByteArrayList!.Count);
-        Assert.Equal(value2, hitResponse.ValueByteArrayList![0]);
-        Assert.Equal(value3, hitResponse.ValueByteArrayList![1]);
+        Assert.Equal(2, hitResponse.ValueListByteArray!.Count);
+        Assert.Equal(value2, hitResponse.ValueListByteArray![0]);
+        Assert.Equal(value3, hitResponse.ValueListByteArray![1]);
     }
 
     [Fact]
@@ -325,9 +325,9 @@ public class ListTest : TestBase
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
-        Assert.Equal(2, hitResponse.ValueStringList!.Count);
-        Assert.Equal(value2, hitResponse.ValueStringList![1]);
-        Assert.Equal(value3, hitResponse.ValueStringList![0]);
+        Assert.Equal(2, hitResponse.ValueListString!.Count);
+        Assert.Equal(value2, hitResponse.ValueListString![1]);
+        Assert.Equal(value3, hitResponse.ValueListString![0]);
     }
 
     [Fact]
@@ -343,9 +343,9 @@ public class ListTest : TestBase
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
-        Assert.Equal(2, hitResponse.ValueByteArrayList!.Count);
-        Assert.Equal(value2, hitResponse.ValueByteArrayList![1]);
-        Assert.Equal(value3, hitResponse.ValueByteArrayList![0]);
+        Assert.Equal(2, hitResponse.ValueListByteArray!.Count);
+        Assert.Equal(value2, hitResponse.ValueListByteArray![1]);
+        Assert.Equal(value3, hitResponse.ValueListByteArray![0]);
     }
 
     [Fact]
@@ -363,7 +363,7 @@ public class ListTest : TestBase
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
 
-        var list = hitResponse.ValueStringList;
+        var list = hitResponse.ValueListString;
         Assert.Single(list);
         Assert.Contains(value1, list);
 
@@ -377,7 +377,7 @@ public class ListTest : TestBase
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
-        list = hitResponse.ValueStringList!;
+        list = hitResponse.ValueListString!;
         Assert.Equal(value1, list[0]);
         Assert.Equal(value2, list[1]);
     }
@@ -411,7 +411,7 @@ public class ListTest : TestBase
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheListFetchResponse.Hit)response;
-        Assert.Equal(2, hitResponse.ValueStringList!.Count);
+        Assert.Equal(2, hitResponse.ValueListString!.Count);
     }
 
     [Fact]
@@ -555,7 +555,7 @@ public class ListTest : TestBase
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
 
-        Assert.Equal(hitResponse.ValueStringList, contentList);
+        Assert.Equal(hitResponse.ValueListString, contentList);
     }
 
     [Fact]
@@ -573,9 +573,9 @@ public class ListTest : TestBase
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
 
-        Assert.Contains(field1, hitResponse.ValueByteArrayList!);
-        Assert.Contains(field2, hitResponse.ValueByteArrayList!);
-        Assert.Equal(2, hitResponse.ValueByteArrayList!.Count);
+        Assert.Contains(field1, hitResponse.ValueListByteArray!);
+        Assert.Contains(field2, hitResponse.ValueListByteArray!);
+        Assert.Equal(2, hitResponse.ValueListByteArray!.Count);
     }
 
     [Theory]
@@ -611,7 +611,7 @@ public class ListTest : TestBase
         // Test not there
         var response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
-        var cachedList = ((CacheListFetchResponse.Hit)response).ValueByteArrayList!;
+        var cachedList = ((CacheListFetchResponse.Hit)response).ValueListByteArray!;
         Assert.True(list.ListEquals(cachedList));
     }
 
@@ -630,7 +630,7 @@ public class ListTest : TestBase
 
         var response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
-        var cachedList = ((CacheListFetchResponse.Hit)response).ValueByteArrayList!;
+        var cachedList = ((CacheListFetchResponse.Hit)response).ValueListByteArray!;
         Assert.True(list.ListEquals(cachedList));
     }
 
@@ -676,7 +676,7 @@ public class ListTest : TestBase
         // Test not there
         var response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
-        var cachedList = ((CacheListFetchResponse.Hit)response).ValueStringList!;
+        var cachedList = ((CacheListFetchResponse.Hit)response).ValueListString!;
         Assert.True(list.SequenceEqual(cachedList));
     }
 
@@ -695,7 +695,7 @@ public class ListTest : TestBase
 
         var response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
-        var cachedList = ((CacheListFetchResponse.Hit)response).ValueStringList!;
+        var cachedList = ((CacheListFetchResponse.Hit)response).ValueListString!;
         Assert.True(list.SequenceEqual(cachedList));
     }
 

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/SetTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/SetTest.cs
@@ -35,7 +35,7 @@ public class SetTest : TestBase
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
 
-        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ByteArraySet;
+        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueByteArraySet;
         Assert.Single(set);
         Assert.Contains(element, set);
     }
@@ -70,7 +70,7 @@ public class SetTest : TestBase
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
-        Assert.Single(((CacheSetFetchResponse.Hit)fetchResponse).ByteArraySet);
+        Assert.Single(((CacheSetFetchResponse.Hit)fetchResponse).ValueByteArraySet);
     }
 
     [Theory]
@@ -96,7 +96,7 @@ public class SetTest : TestBase
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
 
-        var set = ((CacheSetFetchResponse.Hit)fetchResponse).StringSet();
+        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueStringSet;
         Assert.Single(set);
         Assert.Contains(element, set);
     }
@@ -133,7 +133,7 @@ public class SetTest : TestBase
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
-        Assert.Single(((CacheSetFetchResponse.Hit)fetchResponse).StringSet());
+        Assert.Single(((CacheSetFetchResponse.Hit)fetchResponse).ValueStringSet);
     }
 
     [Fact]
@@ -171,7 +171,7 @@ public class SetTest : TestBase
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
 
-        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ByteArraySet;
+        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueByteArraySet;
         Assert.Equal(2, set!.Count);
         Assert.Contains(element1, set);
         Assert.Contains(element2, set);
@@ -211,7 +211,7 @@ public class SetTest : TestBase
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
 
-        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ByteArraySet;
+        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueByteArraySet;
         Assert.Single(set);
         Assert.Contains(element, set);
     }
@@ -251,7 +251,7 @@ public class SetTest : TestBase
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
 
-        var set = ((CacheSetFetchResponse.Hit)fetchResponse).StringSet();
+        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueStringSet;
         Assert.Equal(2, set!.Count);
         Assert.Contains(element1, set);
         Assert.Contains(element2, set);
@@ -292,7 +292,7 @@ public class SetTest : TestBase
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
 
-        var set = ((CacheSetFetchResponse.Hit)fetchResponse).StringSet();
+        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueStringSet;
         Assert.Single(set);
         Assert.Contains(element, set);
     }
@@ -323,7 +323,7 @@ public class SetTest : TestBase
         // Fetch the whole set and make sure response has element we expect
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
-        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ByteArraySet;
+        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueByteArraySet;
         Assert.Single(set);
         Assert.Contains(element, set);
 
@@ -376,7 +376,7 @@ public class SetTest : TestBase
         Assert.True(removeResponse is CacheSetRemoveElementResponse.Success, $"Unexpected response: {removeResponse}");
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
-        var set = ((CacheSetFetchResponse.Hit)fetchResponse).StringSet();
+        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueStringSet;
         Assert.Single(set);
         Assert.Contains(element, set);
 
@@ -459,8 +459,8 @@ public class SetTest : TestBase
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheSetFetchResponse.Hit)fetchResponse;
-        Assert.Single(hitResponse.ByteArraySet!);
-        Assert.Contains(otherElement, hitResponse.ByteArraySet!);
+        Assert.Single(hitResponse.ValueByteArraySet!);
+        Assert.Contains(otherElement, hitResponse.ValueByteArraySet!);
     }
 
     [Fact]
@@ -518,8 +518,8 @@ public class SetTest : TestBase
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheSetFetchResponse.Hit)fetchResponse;
-        Assert.Single(hitResponse.ByteArraySet!);
-        Assert.Contains(otherElement, hitResponse.ByteArraySet!);
+        Assert.Single(hitResponse.ValueByteArraySet!);
+        Assert.Contains(otherElement, hitResponse.ValueByteArraySet!);
     }
 
     [Theory]
@@ -549,8 +549,8 @@ public class SetTest : TestBase
         CacheSetFetchResponse response = await client.SetFetchAsync(cacheName, setName);
         Assert.True(response is CacheSetFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheSetFetchResponse.Hit)response;
-        var set1 = hitResponse.ByteArraySet;
-        var set2 = hitResponse.ByteArraySet;
+        var set1 = hitResponse.ValueByteArraySet;
+        var set2 = hitResponse.ValueByteArraySet;
         Assert.Same(set1, set2);
     }
 
@@ -563,8 +563,8 @@ public class SetTest : TestBase
         CacheSetFetchResponse response = await client.SetFetchAsync(cacheName, setName);
         Assert.True(response is CacheSetFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheSetFetchResponse.Hit)response;
-        var set1 = hitResponse.StringSet();
-        var set2 = hitResponse.StringSet();
+        var set1 = hitResponse.ValueStringSet;
+        var set2 = hitResponse.ValueStringSet;
         Assert.Same(set1, set2);
     }
 

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/SetTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/SetTest.cs
@@ -35,7 +35,7 @@ public class SetTest : TestBase
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
 
-        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueByteArraySet;
+        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueSetByteArray;
         Assert.Single(set);
         Assert.Contains(element, set);
     }
@@ -70,7 +70,7 @@ public class SetTest : TestBase
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
-        Assert.Single(((CacheSetFetchResponse.Hit)fetchResponse).ValueByteArraySet);
+        Assert.Single(((CacheSetFetchResponse.Hit)fetchResponse).ValueSetByteArray);
     }
 
     [Theory]
@@ -96,7 +96,7 @@ public class SetTest : TestBase
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
 
-        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueStringSet;
+        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueSetString;
         Assert.Single(set);
         Assert.Contains(element, set);
     }
@@ -133,7 +133,7 @@ public class SetTest : TestBase
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
-        Assert.Single(((CacheSetFetchResponse.Hit)fetchResponse).ValueStringSet);
+        Assert.Single(((CacheSetFetchResponse.Hit)fetchResponse).ValueSetString);
     }
 
     [Fact]
@@ -171,7 +171,7 @@ public class SetTest : TestBase
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
 
-        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueByteArraySet;
+        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueSetByteArray;
         Assert.Equal(2, set!.Count);
         Assert.Contains(element1, set);
         Assert.Contains(element2, set);
@@ -211,7 +211,7 @@ public class SetTest : TestBase
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
 
-        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueByteArraySet;
+        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueSetByteArray;
         Assert.Single(set);
         Assert.Contains(element, set);
     }
@@ -251,7 +251,7 @@ public class SetTest : TestBase
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
 
-        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueStringSet;
+        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueSetString;
         Assert.Equal(2, set!.Count);
         Assert.Contains(element1, set);
         Assert.Contains(element2, set);
@@ -292,7 +292,7 @@ public class SetTest : TestBase
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
 
-        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueStringSet;
+        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueSetString;
         Assert.Single(set);
         Assert.Contains(element, set);
     }
@@ -323,7 +323,7 @@ public class SetTest : TestBase
         // Fetch the whole set and make sure response has element we expect
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
-        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueByteArraySet;
+        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueSetByteArray;
         Assert.Single(set);
         Assert.Contains(element, set);
 
@@ -376,7 +376,7 @@ public class SetTest : TestBase
         Assert.True(removeResponse is CacheSetRemoveElementResponse.Success, $"Unexpected response: {removeResponse}");
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
-        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueStringSet;
+        var set = ((CacheSetFetchResponse.Hit)fetchResponse).ValueSetString;
         Assert.Single(set);
         Assert.Contains(element, set);
 
@@ -459,8 +459,8 @@ public class SetTest : TestBase
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheSetFetchResponse.Hit)fetchResponse;
-        Assert.Single(hitResponse.ValueByteArraySet!);
-        Assert.Contains(otherElement, hitResponse.ValueByteArraySet!);
+        Assert.Single(hitResponse.ValueSetByteArray!);
+        Assert.Contains(otherElement, hitResponse.ValueSetByteArray!);
     }
 
     [Fact]
@@ -518,8 +518,8 @@ public class SetTest : TestBase
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheSetFetchResponse.Hit)fetchResponse;
-        Assert.Single(hitResponse.ValueByteArraySet!);
-        Assert.Contains(otherElement, hitResponse.ValueByteArraySet!);
+        Assert.Single(hitResponse.ValueSetByteArray!);
+        Assert.Contains(otherElement, hitResponse.ValueSetByteArray!);
     }
 
     [Theory]
@@ -549,8 +549,8 @@ public class SetTest : TestBase
         CacheSetFetchResponse response = await client.SetFetchAsync(cacheName, setName);
         Assert.True(response is CacheSetFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheSetFetchResponse.Hit)response;
-        var set1 = hitResponse.ValueByteArraySet;
-        var set2 = hitResponse.ValueByteArraySet;
+        var set1 = hitResponse.ValueSetByteArray;
+        var set2 = hitResponse.ValueSetByteArray;
         Assert.Same(set1, set2);
     }
 
@@ -563,8 +563,8 @@ public class SetTest : TestBase
         CacheSetFetchResponse response = await client.SetFetchAsync(cacheName, setName);
         Assert.True(response is CacheSetFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheSetFetchResponse.Hit)response;
-        var set1 = hitResponse.ValueStringSet;
-        var set2 = hitResponse.ValueStringSet;
+        var set1 = hitResponse.ValueSetString;
+        var set2 = hitResponse.ValueSetString;
         Assert.Same(set1, set2);
     }
 


### PR DESCRIPTION
- Made all value accessors be properties
- Updated value accessors name to pre-fix with `.Value`
- Renamed value accessors to bring collection type to the beginning
- Bumped SDK version to `1.0.0`

Closes #51 
Closes #53 
Closes #54 