### PR TITLE
chore: rename dictionary set and set add

### DIFF
--- a/src/Momento.Sdk.Incubating/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk.Incubating/Internal/ScsDataClient.cs
@@ -131,32 +131,32 @@ internal sealed class ScsDataClient : ScsDataClientBase
     private _DictionaryFieldValuePair[] ToSingletonFieldValuePair(string field, string value) => new _DictionaryFieldValuePair[] { new _DictionaryFieldValuePair() { Field = field.ToByteString(), Value = value.ToByteString() } };
     private _DictionaryFieldValuePair[] ToSingletonFieldValuePair(string field, byte[] value) => new _DictionaryFieldValuePair[] { new _DictionaryFieldValuePair() { Field = field.ToByteString(), Value = value.ToByteString() } };
 
-    public async Task<CacheDictionarySetFieldResponse> DictionarySetAsync(string cacheName, string dictionaryName, byte[] field, byte[] value, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldResponse> DictionarySetFieldAsync(string cacheName, string dictionaryName, byte[] field, byte[] value, CollectionTtl ttl = default(CollectionTtl))
     {
-        return await SendDictionarySetAsync(cacheName, dictionaryName, ToSingletonFieldValuePair(field, value), ttl);
+        return await SendDictionarySetFieldAsync(cacheName, dictionaryName, ToSingletonFieldValuePair(field, value), ttl);
     }
 
-    public async Task<CacheDictionarySetFieldResponse> DictionarySetAsync(string cacheName, string dictionaryName, string field, string value, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldResponse> DictionarySetFieldAsync(string cacheName, string dictionaryName, string field, string value, CollectionTtl ttl = default(CollectionTtl))
     {
-        return await SendDictionarySetAsync(cacheName, dictionaryName, ToSingletonFieldValuePair(field, value), ttl);
+        return await SendDictionarySetFieldAsync(cacheName, dictionaryName, ToSingletonFieldValuePair(field, value), ttl);
     }
 
-    public async Task<CacheDictionarySetFieldResponse> DictionarySetAsync(string cacheName, string dictionaryName, string field, byte[] value, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldResponse> DictionarySetFieldAsync(string cacheName, string dictionaryName, string field, byte[] value, CollectionTtl ttl = default(CollectionTtl))
     {
-        return await SendDictionarySetAsync(cacheName, dictionaryName, ToSingletonFieldValuePair(field, value), ttl);
+        return await SendDictionarySetFieldAsync(cacheName, dictionaryName, ToSingletonFieldValuePair(field, value), ttl);
     }
 
-    public async Task<CacheDictionaryGetFieldResponse> DictionaryGetAsync(string cacheName, string dictionaryName, byte[] field)
+    public async Task<CacheDictionaryGetFieldResponse> DictionaryGetFieldAsync(string cacheName, string dictionaryName, byte[] field)
     {
-        return await SendDictionaryGetAsync(cacheName, dictionaryName, field.ToSingletonByteString());
+        return await SendDictionaryGetFieldAsync(cacheName, dictionaryName, field.ToSingletonByteString());
     }
 
-    public async Task<CacheDictionaryGetFieldResponse> DictionaryGetAsync(string cacheName, string dictionaryName, string field)
+    public async Task<CacheDictionaryGetFieldResponse> DictionaryGetFieldAsync(string cacheName, string dictionaryName, string field)
     {
-        return await SendDictionaryGetAsync(cacheName, dictionaryName, field.ToSingletonByteString());
+        return await SendDictionaryGetFieldAsync(cacheName, dictionaryName, field.ToSingletonByteString());
     }
 
-    private async Task<CacheDictionaryGetFieldResponse> SendDictionaryGetAsync(string cacheName, string dictionaryName, IEnumerable<ByteString> fields)
+    private async Task<CacheDictionaryGetFieldResponse> SendDictionaryGetFieldAsync(string cacheName, string dictionaryName, IEnumerable<ByteString> fields)
     {
         _DictionaryGetRequest request = new() { DictionaryName = dictionaryName.ToByteString() };
         request.Fields.Add(fields);
@@ -195,25 +195,25 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheDictionaryGetFieldResponse.Hit(response);
     }
 
-    public async Task<CacheDictionarySetFieldsResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
     {
         var protoItems = items.Select(kv => new _DictionaryFieldValuePair() { Field = kv.Key.ToByteString(), Value = kv.Value.ToByteString() });
-        return await SendDictionarySetBatchAsync(cacheName, dictionaryName, protoItems, ttl);
+        return await SendDictionarySetFieldsAsync(cacheName, dictionaryName, protoItems, ttl);
     }
 
-    public async Task<CacheDictionarySetFieldsResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, string>> items, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, string>> items, CollectionTtl ttl = default(CollectionTtl))
     {
         var protoItems = items.Select(kv => new _DictionaryFieldValuePair() { Field = kv.Key.ToByteString(), Value = kv.Value.ToByteString() });
-        return await SendDictionarySetBatchAsync(cacheName, dictionaryName, protoItems, ttl);
+        return await SendDictionarySetFieldsAsync(cacheName, dictionaryName, protoItems, ttl);
     }
 
-    public async Task<CacheDictionarySetFieldsResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
     {
         var protoItems = items.Select(kv => new _DictionaryFieldValuePair() { Field = kv.Key.ToByteString(), Value = kv.Value.ToByteString() });
-        return await SendDictionarySetBatchAsync(cacheName, dictionaryName, protoItems, ttl);
+        return await SendDictionarySetFieldsAsync(cacheName, dictionaryName, protoItems, ttl);
     }
 
-    public async Task<CacheDictionarySetFieldResponse> SendDictionarySetAsync(string cacheName, string dictionaryName, IEnumerable<_DictionaryFieldValuePair> items, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldResponse> SendDictionarySetFieldAsync(string cacheName, string dictionaryName, IEnumerable<_DictionaryFieldValuePair> items, CollectionTtl ttl = default(CollectionTtl))
     {
         _DictionarySetRequest request = new()
         {
@@ -234,7 +234,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheDictionarySetFieldResponse.Success();
     }
 
-    public async Task<CacheDictionarySetFieldsResponse> SendDictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<_DictionaryFieldValuePair> items, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldsResponse> SendDictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<_DictionaryFieldValuePair> items, CollectionTtl ttl = default(CollectionTtl))
     {
         _DictionarySetRequest request = new()
         {
@@ -283,17 +283,17 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheDictionaryIncrementResponse.Success(response);
     }
 
-    public async Task<CacheDictionaryGetFieldsResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
+    public async Task<CacheDictionaryGetFieldsResponse> DictionaryGetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
     {
-        return await SendDictionaryGetBatchAsync(cacheName, dictionaryName, fields.ToEnumerableByteString());
+        return await SendDictionaryGetFieldsAsync(cacheName, dictionaryName, fields.ToEnumerableByteString());
     }
 
-    public async Task<CacheDictionaryGetFieldsResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<string> fields)
+    public async Task<CacheDictionaryGetFieldsResponse> DictionaryGetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<string> fields)
     {
-        return await SendDictionaryGetBatchAsync(cacheName, dictionaryName, fields.ToEnumerableByteString());
+        return await SendDictionaryGetFieldsAsync(cacheName, dictionaryName, fields.ToEnumerableByteString());
     }
 
-    private async Task<CacheDictionaryGetFieldsResponse> SendDictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<ByteString> fields)
+    private async Task<CacheDictionaryGetFieldsResponse> SendDictionaryGetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<ByteString> fields)
     {
         _DictionaryGetRequest request = new() { DictionaryName = dictionaryName.ToByteString() };
         request.Fields.Add(fields);
@@ -436,27 +436,27 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheDictionaryRemoveFieldsResponse.Success();
     }
 
-    public async Task<CacheSetAddElementResponse> SetAddAsync(string cacheName, string setName, byte[] element, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheSetAddElementResponse> SetAddElementAsync(string cacheName, string setName, byte[] element, CollectionTtl ttl = default(CollectionTtl))
     {
-        return await SendSetAddAsync(cacheName, setName, element.ToSingletonByteString(), ttl);
+        return await SendSetAddElementAsync(cacheName, setName, element.ToSingletonByteString(), ttl);
     }
 
-    public async Task<CacheSetAddElementResponse> SetAddAsync(string cacheName, string setName, string element, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheSetAddElementResponse> SetAddElementAsync(string cacheName, string setName, string element, CollectionTtl ttl = default(CollectionTtl))
     {
-        return await SendSetAddAsync(cacheName, setName, element.ToSingletonByteString(), ttl);
+        return await SendSetAddElementAsync(cacheName, setName, element.ToSingletonByteString(), ttl);
     }
 
-    public async Task<CacheSetAddElementsResponse> SetAddBatchAsync(string cacheName, string setName, IEnumerable<byte[]> elements, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheSetAddElementsResponse> SetAddElementsAsync(string cacheName, string setName, IEnumerable<byte[]> elements, CollectionTtl ttl = default(CollectionTtl))
     {
-        return await SendSetAddBatchAsync(cacheName, setName, elements.ToEnumerableByteString(), ttl);
+        return await SendSetAddElementsAsync(cacheName, setName, elements.ToEnumerableByteString(), ttl);
     }
 
-    public async Task<CacheSetAddElementsResponse> SetAddBatchAsync(string cacheName, string setName, IEnumerable<string> elements, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheSetAddElementsResponse> SetAddElementsAsync(string cacheName, string setName, IEnumerable<string> elements, CollectionTtl ttl = default(CollectionTtl))
     {
-        return await SendSetAddBatchAsync(cacheName, setName, elements.ToEnumerableByteString(), ttl);
+        return await SendSetAddElementsAsync(cacheName, setName, elements.ToEnumerableByteString(), ttl);
     }
 
-    public async Task<CacheSetAddElementResponse> SendSetAddAsync(string cacheName, string setName, IEnumerable<ByteString> elements, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheSetAddElementResponse> SendSetAddElementAsync(string cacheName, string setName, IEnumerable<ByteString> elements, CollectionTtl ttl = default(CollectionTtl))
     {
         _SetUnionRequest request = new()
         {
@@ -481,7 +481,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheSetAddElementResponse.Success();
     }
 
-    public async Task<CacheSetAddElementsResponse> SendSetAddBatchAsync(string cacheName, string setName, IEnumerable<ByteString> elements, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheSetAddElementsResponse> SendSetAddElementsAsync(string cacheName, string setName, IEnumerable<ByteString> elements, CollectionTtl ttl = default(CollectionTtl))
     {
         _SetUnionRequest request = new()
         {

--- a/src/Momento.Sdk.Incubating/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk.Incubating/Internal/ScsDataClient.cs
@@ -131,32 +131,32 @@ internal sealed class ScsDataClient : ScsDataClientBase
     private _DictionaryFieldValuePair[] ToSingletonFieldValuePair(string field, string value) => new _DictionaryFieldValuePair[] { new _DictionaryFieldValuePair() { Field = field.ToByteString(), Value = value.ToByteString() } };
     private _DictionaryFieldValuePair[] ToSingletonFieldValuePair(string field, byte[] value) => new _DictionaryFieldValuePair[] { new _DictionaryFieldValuePair() { Field = field.ToByteString(), Value = value.ToByteString() } };
 
-    public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, byte[] field, byte[] value, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldResponse> DictionarySetAsync(string cacheName, string dictionaryName, byte[] field, byte[] value, CollectionTtl ttl = default(CollectionTtl))
     {
         return await SendDictionarySetAsync(cacheName, dictionaryName, ToSingletonFieldValuePair(field, value), ttl);
     }
 
-    public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, string field, string value, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldResponse> DictionarySetAsync(string cacheName, string dictionaryName, string field, string value, CollectionTtl ttl = default(CollectionTtl))
     {
         return await SendDictionarySetAsync(cacheName, dictionaryName, ToSingletonFieldValuePair(field, value), ttl);
     }
 
-    public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, string field, byte[] value, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldResponse> DictionarySetAsync(string cacheName, string dictionaryName, string field, byte[] value, CollectionTtl ttl = default(CollectionTtl))
     {
         return await SendDictionarySetAsync(cacheName, dictionaryName, ToSingletonFieldValuePair(field, value), ttl);
     }
 
-    public async Task<CacheDictionaryGetResponse> DictionaryGetAsync(string cacheName, string dictionaryName, byte[] field)
+    public async Task<CacheDictionaryGetFieldResponse> DictionaryGetAsync(string cacheName, string dictionaryName, byte[] field)
     {
         return await SendDictionaryGetAsync(cacheName, dictionaryName, field.ToSingletonByteString());
     }
 
-    public async Task<CacheDictionaryGetResponse> DictionaryGetAsync(string cacheName, string dictionaryName, string field)
+    public async Task<CacheDictionaryGetFieldResponse> DictionaryGetAsync(string cacheName, string dictionaryName, string field)
     {
         return await SendDictionaryGetAsync(cacheName, dictionaryName, field.ToSingletonByteString());
     }
 
-    private async Task<CacheDictionaryGetResponse> SendDictionaryGetAsync(string cacheName, string dictionaryName, IEnumerable<ByteString> fields)
+    private async Task<CacheDictionaryGetFieldResponse> SendDictionaryGetAsync(string cacheName, string dictionaryName, IEnumerable<ByteString> fields)
     {
         _DictionaryGetRequest request = new() { DictionaryName = dictionaryName.ToByteString() };
         request.Fields.Add(fields);
@@ -173,47 +173,47 @@ internal sealed class ScsDataClient : ScsDataClientBase
             {
                 exc.TransportDetails.Grpc.Metadata = MetadataWithCache(cacheName);
             }
-            return new CacheDictionaryGetResponse.Error(exc);
+            return new CacheDictionaryGetFieldResponse.Error(exc);
         }
 
         if (response.DictionaryCase == _DictionaryGetResponse.DictionaryOneofCase.Missing)
         {
-            return new CacheDictionaryGetResponse.Miss();
+            return new CacheDictionaryGetFieldResponse.Miss();
         }
 
         if (response.Found.Items.Count == 0)
         {
             var exc = _exceptionMapper.Convert(new Exception("_DictionaryGetResponseResponse contained no data but was found"));
-            return new CacheDictionaryGetResponse.Error(exc);
+            return new CacheDictionaryGetFieldResponse.Error(exc);
         }
 
         if (response.Found.Items[0].Result == ECacheResult.Miss)
         {
-            return new CacheDictionaryGetResponse.Miss();
+            return new CacheDictionaryGetFieldResponse.Miss();
         }
 
-        return new CacheDictionaryGetResponse.Hit(response);
+        return new CacheDictionaryGetFieldResponse.Hit(response);
     }
 
-    public async Task<CacheDictionarySetBatchResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
     {
         var protoItems = items.Select(kv => new _DictionaryFieldValuePair() { Field = kv.Key.ToByteString(), Value = kv.Value.ToByteString() });
         return await SendDictionarySetBatchAsync(cacheName, dictionaryName, protoItems, ttl);
     }
 
-    public async Task<CacheDictionarySetBatchResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, string>> items, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, string>> items, CollectionTtl ttl = default(CollectionTtl))
     {
         var protoItems = items.Select(kv => new _DictionaryFieldValuePair() { Field = kv.Key.ToByteString(), Value = kv.Value.ToByteString() });
         return await SendDictionarySetBatchAsync(cacheName, dictionaryName, protoItems, ttl);
     }
 
-    public async Task<CacheDictionarySetBatchResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
     {
         var protoItems = items.Select(kv => new _DictionaryFieldValuePair() { Field = kv.Key.ToByteString(), Value = kv.Value.ToByteString() });
         return await SendDictionarySetBatchAsync(cacheName, dictionaryName, protoItems, ttl);
     }
 
-    public async Task<CacheDictionarySetResponse> SendDictionarySetAsync(string cacheName, string dictionaryName, IEnumerable<_DictionaryFieldValuePair> items, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldResponse> SendDictionarySetAsync(string cacheName, string dictionaryName, IEnumerable<_DictionaryFieldValuePair> items, CollectionTtl ttl = default(CollectionTtl))
     {
         _DictionarySetRequest request = new()
         {
@@ -229,12 +229,12 @@ internal sealed class ScsDataClient : ScsDataClientBase
         }
         catch (Exception e)
         {
-            return new CacheDictionarySetResponse.Error(_exceptionMapper.Convert(e));
+            return new CacheDictionarySetFieldResponse.Error(_exceptionMapper.Convert(e));
         }
-        return new CacheDictionarySetResponse.Success();
+        return new CacheDictionarySetFieldResponse.Success();
     }
 
-    public async Task<CacheDictionarySetBatchResponse> SendDictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<_DictionaryFieldValuePair> items, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldsResponse> SendDictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<_DictionaryFieldValuePair> items, CollectionTtl ttl = default(CollectionTtl))
     {
         _DictionarySetRequest request = new()
         {
@@ -250,9 +250,9 @@ internal sealed class ScsDataClient : ScsDataClientBase
         }
         catch (Exception e)
         {
-            return new CacheDictionarySetBatchResponse.Error(_exceptionMapper.Convert(e));
+            return new CacheDictionarySetFieldsResponse.Error(_exceptionMapper.Convert(e));
         }
-        return new CacheDictionarySetBatchResponse.Success();
+        return new CacheDictionarySetFieldsResponse.Success();
     }
 
     public async Task<CacheDictionaryIncrementResponse> DictionaryIncrementAsync(string cacheName, string dictionaryName, string field, long amount = 1, CollectionTtl ttl = default(CollectionTtl))
@@ -283,17 +283,17 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheDictionaryIncrementResponse.Success(response);
     }
 
-    public async Task<CacheDictionaryGetBatchResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
+    public async Task<CacheDictionaryGetFieldsResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
     {
         return await SendDictionaryGetBatchAsync(cacheName, dictionaryName, fields.ToEnumerableByteString());
     }
 
-    public async Task<CacheDictionaryGetBatchResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<string> fields)
+    public async Task<CacheDictionaryGetFieldsResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<string> fields)
     {
         return await SendDictionaryGetBatchAsync(cacheName, dictionaryName, fields.ToEnumerableByteString());
     }
 
-    private async Task<CacheDictionaryGetBatchResponse> SendDictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<ByteString> fields)
+    private async Task<CacheDictionaryGetFieldsResponse> SendDictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<ByteString> fields)
     {
         _DictionaryGetRequest request = new() { DictionaryName = dictionaryName.ToByteString() };
         request.Fields.Add(fields);
@@ -310,13 +310,13 @@ internal sealed class ScsDataClient : ScsDataClientBase
             {
                 exc.TransportDetails.Grpc.Metadata = MetadataWithCache(cacheName);
             }
-            return new CacheDictionaryGetBatchResponse.Error(exc);
+            return new CacheDictionaryGetFieldsResponse.Error(exc);
         }
         if (response.DictionaryCase == _DictionaryGetResponse.DictionaryOneofCase.Found)
         {
-            return new CacheDictionaryGetBatchResponse.Success(response);
+            return new CacheDictionaryGetFieldsResponse.Success(response);
         }
-        return new CacheDictionaryGetBatchResponse.Success(fields.Count());
+        return new CacheDictionaryGetFieldsResponse.Success(fields.Count());
     }
 
     public async Task<CacheDictionaryFetchResponse> DictionaryFetchAsync(string cacheName, string dictionaryName)
@@ -436,27 +436,27 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheDictionaryRemoveFieldsResponse.Success();
     }
 
-    public async Task<CacheSetAddResponse> SetAddAsync(string cacheName, string setName, byte[] element, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheSetAddElementResponse> SetAddAsync(string cacheName, string setName, byte[] element, CollectionTtl ttl = default(CollectionTtl))
     {
         return await SendSetAddAsync(cacheName, setName, element.ToSingletonByteString(), ttl);
     }
 
-    public async Task<CacheSetAddResponse> SetAddAsync(string cacheName, string setName, string element, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheSetAddElementResponse> SetAddAsync(string cacheName, string setName, string element, CollectionTtl ttl = default(CollectionTtl))
     {
         return await SendSetAddAsync(cacheName, setName, element.ToSingletonByteString(), ttl);
     }
 
-    public async Task<CacheSetAddBatchResponse> SetAddBatchAsync(string cacheName, string setName, IEnumerable<byte[]> elements, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheSetAddElementsResponse> SetAddBatchAsync(string cacheName, string setName, IEnumerable<byte[]> elements, CollectionTtl ttl = default(CollectionTtl))
     {
         return await SendSetAddBatchAsync(cacheName, setName, elements.ToEnumerableByteString(), ttl);
     }
 
-    public async Task<CacheSetAddBatchResponse> SetAddBatchAsync(string cacheName, string setName, IEnumerable<string> elements, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheSetAddElementsResponse> SetAddBatchAsync(string cacheName, string setName, IEnumerable<string> elements, CollectionTtl ttl = default(CollectionTtl))
     {
         return await SendSetAddBatchAsync(cacheName, setName, elements.ToEnumerableByteString(), ttl);
     }
 
-    public async Task<CacheSetAddResponse> SendSetAddAsync(string cacheName, string setName, IEnumerable<ByteString> elements, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheSetAddElementResponse> SendSetAddAsync(string cacheName, string setName, IEnumerable<ByteString> elements, CollectionTtl ttl = default(CollectionTtl))
     {
         _SetUnionRequest request = new()
         {
@@ -476,12 +476,12 @@ internal sealed class ScsDataClient : ScsDataClientBase
             {
                 exc.TransportDetails.Grpc.Metadata = MetadataWithCache(cacheName);
             }
-            return new CacheSetAddResponse.Error(exc);
+            return new CacheSetAddElementResponse.Error(exc);
         }
-        return new CacheSetAddResponse.Success();
+        return new CacheSetAddElementResponse.Success();
     }
 
-    public async Task<CacheSetAddBatchResponse> SendSetAddBatchAsync(string cacheName, string setName, IEnumerable<ByteString> elements, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheSetAddElementsResponse> SendSetAddBatchAsync(string cacheName, string setName, IEnumerable<ByteString> elements, CollectionTtl ttl = default(CollectionTtl))
     {
         _SetUnionRequest request = new()
         {
@@ -501,9 +501,9 @@ internal sealed class ScsDataClient : ScsDataClientBase
             {
                 exc.TransportDetails.Grpc.Metadata = MetadataWithCache(cacheName);
             }
-            return new CacheSetAddBatchResponse.Error(exc);
+            return new CacheSetAddElementsResponse.Error(exc);
         }
-        return new CacheSetAddBatchResponse.Success();
+        return new CacheSetAddElementsResponse.Success();
     }
 
     public async Task<CacheSetRemoveElementResponse> SetRemoveElementAsync(string cacheName, string setName, byte[] element)

--- a/src/Momento.Sdk.Incubating/Responses/CacheDictionaryGetFieldResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheDictionaryGetFieldResponse.cs
@@ -6,9 +6,9 @@ using Momento.Sdk.Responses;
 
 namespace Momento.Sdk.Incubating.Responses;
 
-public abstract class CacheDictionaryGetResponse
+public abstract class CacheDictionaryGetFieldResponse
 {
-    public class Hit : CacheDictionaryGetResponse
+    public class Hit : CacheDictionaryGetFieldResponse
     {
         protected readonly ByteString value;
 
@@ -30,12 +30,12 @@ public abstract class CacheDictionaryGetResponse
         public string ValueString { get => value.ToStringUtf8(); }
     }
 
-    public class Miss : CacheDictionaryGetResponse
+    public class Miss : CacheDictionaryGetFieldResponse
     {
 
     }
 
-    public class Error : CacheDictionaryGetResponse
+    public class Error : CacheDictionaryGetFieldResponse
     {
         private readonly SdkException _error;
         public Error(SdkException error)

--- a/src/Momento.Sdk.Incubating/Responses/CacheDictionaryGetFieldsResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheDictionaryGetFieldsResponse.cs
@@ -9,28 +9,28 @@ using static Momento.Protos.CacheClient._DictionaryGetResponse.Types;
 
 namespace Momento.Sdk.Incubating.Responses;
 
-public abstract class CacheDictionaryGetBatchResponse
+public abstract class CacheDictionaryGetFieldsResponse
 {
-    public class Success : CacheDictionaryGetBatchResponse
+    public class Success : CacheDictionaryGetFieldsResponse
     {
-        public List<CacheDictionaryGetResponse> Responses { get; private set; }
+        public List<CacheDictionaryGetFieldResponse> Responses { get; private set; }
 
         public Success(_DictionaryGetResponse responses)
         {
-            var responsesList = new List<CacheDictionaryGetResponse>();
+            var responsesList = new List<CacheDictionaryGetFieldResponse>();
             foreach (_DictionaryGetResponsePart response in responses.Found.Items)
             {
                 if (response.Result == ECacheResult.Hit)
                 {
-                    responsesList.Add(new CacheDictionaryGetResponse.Hit(response.CacheBody));
+                    responsesList.Add(new CacheDictionaryGetFieldResponse.Hit(response.CacheBody));
                 }
                 else if (response.Result == ECacheResult.Miss)
                 {
-                    responsesList.Add(new CacheDictionaryGetResponse.Miss());
+                    responsesList.Add(new CacheDictionaryGetFieldResponse.Miss());
                 }
                 else
                 {
-                    responsesList.Add(new CacheDictionaryGetResponse.Error(new UnknownException(response.Result.ToString())));
+                    responsesList.Add(new CacheDictionaryGetFieldResponse.Error(new UnknownException(response.Result.ToString())));
                 }
             }
             this.Responses = responsesList;
@@ -38,7 +38,7 @@ public abstract class CacheDictionaryGetBatchResponse
 
         public Success(int numRequested)
         {
-            Responses = Enumerable.Range(1, numRequested).Select(_ => new CacheDictionaryGetResponse.Miss()).ToList<CacheDictionaryGetResponse>();
+            Responses = Enumerable.Range(1, numRequested).Select(_ => new CacheDictionaryGetFieldResponse.Miss()).ToList<CacheDictionaryGetFieldResponse>();
         }
 
         public IEnumerable<string?> ValueStrings
@@ -46,13 +46,13 @@ public abstract class CacheDictionaryGetBatchResponse
             get
             {
                 var ret = new List<string?>();
-                foreach (CacheDictionaryGetResponse response in Responses)
+                foreach (CacheDictionaryGetFieldResponse response in Responses)
                 {
-                    if (response is CacheDictionaryGetResponse.Hit hitResponse)
+                    if (response is CacheDictionaryGetFieldResponse.Hit hitResponse)
                     {
                         ret.Add(hitResponse.ValueString);
                     }
-                    else if (response is CacheDictionaryGetResponse.Miss missResponse)
+                    else if (response is CacheDictionaryGetFieldResponse.Miss missResponse)
                     {
                         ret.Add(null);
                     }
@@ -66,13 +66,13 @@ public abstract class CacheDictionaryGetBatchResponse
             get
             {
                 var ret = new List<byte[]?>();
-                foreach (CacheDictionaryGetResponse response in Responses)
+                foreach (CacheDictionaryGetFieldResponse response in Responses)
                 {
-                    if (response is CacheDictionaryGetResponse.Hit hitResponse)
+                    if (response is CacheDictionaryGetFieldResponse.Hit hitResponse)
                     {
                         ret.Add(hitResponse.ValueByteArray);
                     }
-                    else if (response is CacheDictionaryGetResponse.Miss missResponse)
+                    else if (response is CacheDictionaryGetFieldResponse.Miss missResponse)
                     {
                         ret.Add(null);
                     }
@@ -82,7 +82,7 @@ public abstract class CacheDictionaryGetBatchResponse
         }
     }
 
-    public class Error : CacheDictionaryGetBatchResponse
+    public class Error : CacheDictionaryGetFieldsResponse
     {
         private readonly SdkException _error;
         public Error(SdkException error)

--- a/src/Momento.Sdk.Incubating/Responses/CacheDictionarySetFieldResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheDictionarySetFieldResponse.cs
@@ -1,13 +1,14 @@
-using Momento.Sdk.Exceptions;
+﻿using Momento.Sdk.Exceptions;
 
 namespace Momento.Sdk.Incubating.Responses;
 
-public abstract class CacheSetAddBatchResponse
+public abstract class CacheDictionarySetFieldResponse
 {
-    public class Success : CacheSetAddBatchResponse
+    public class Success : CacheDictionarySetFieldResponse
     {
+
     }
-    public class Error : CacheSetAddBatchResponse
+    public class Error : CacheDictionarySetFieldResponse
     {
         private readonly SdkException _error;
         public Error(SdkException error)
@@ -35,5 +36,4 @@ public abstract class CacheSetAddBatchResponse
             return base.ToString() + ": " + Message;
         }
     }
-
 }

--- a/src/Momento.Sdk.Incubating/Responses/CacheDictionarySetFieldsResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheDictionarySetFieldsResponse.cs
@@ -2,13 +2,12 @@
 
 namespace Momento.Sdk.Incubating.Responses;
 
-public abstract class CacheDictionarySetResponse
+public abstract class CacheDictionarySetFieldsResponse
 {
-    public class Success : CacheDictionarySetResponse
+    public class Success : CacheDictionarySetFieldsResponse
     {
-
     }
-    public class Error : CacheDictionarySetResponse
+    public class Error : CacheDictionarySetFieldsResponse
     {
         private readonly SdkException _error;
         public Error(SdkException error)
@@ -36,4 +35,5 @@ public abstract class CacheDictionarySetResponse
             return base.ToString() + ": " + Message;
         }
     }
+
 }

--- a/src/Momento.Sdk.Incubating/Responses/CacheSetAddElementResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheSetAddElementResponse.cs
@@ -2,12 +2,12 @@ using Momento.Sdk.Exceptions;
 
 namespace Momento.Sdk.Incubating.Responses;
 
-public abstract class CacheSetAddResponse
+public abstract class CacheSetAddElementResponse
 {
-    public class Success : CacheSetAddResponse
+    public class Success : CacheSetAddElementResponse
     {
     }
-    public class Error : CacheSetAddResponse
+    public class Error : CacheSetAddElementResponse
     {
         private readonly SdkException _error;
         public Error(SdkException error)

--- a/src/Momento.Sdk.Incubating/Responses/CacheSetAddElementsResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheSetAddElementsResponse.cs
@@ -1,13 +1,13 @@
-﻿using Momento.Sdk.Exceptions;
+using Momento.Sdk.Exceptions;
 
 namespace Momento.Sdk.Incubating.Responses;
 
-public abstract class CacheDictionarySetBatchResponse
+public abstract class CacheSetAddElementsResponse
 {
-    public class Success : CacheDictionarySetBatchResponse
+    public class Success : CacheSetAddElementsResponse
     {
     }
-    public class Error : CacheDictionarySetBatchResponse
+    public class Error : CacheSetAddElementsResponse
     {
         private readonly SdkException _error;
         public Error(SdkException error)

--- a/src/Momento.Sdk.Incubating/SimpleCacheClient.cs
+++ b/src/Momento.Sdk.Incubating/SimpleCacheClient.cs
@@ -194,7 +194,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="value">The value to be stored.</param>
     /// <param name="ttl">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    public async Task<CacheDictionarySetFieldResponse> DictionarySetAsync(string cacheName, string dictionaryName, byte[] field, byte[] value, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldResponse> DictionarySetFieldAsync(string cacheName, string dictionaryName, byte[] field, byte[] value, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
@@ -208,11 +208,11 @@ public class SimpleCacheClient : ISimpleCacheClient
             return new CacheDictionarySetFieldResponse.Error(new InvalidArgumentException(e.Message));
         }
 
-        return await this.dataClient.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl);
+        return await this.dataClient.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl);
     }
 
-    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], CollectionTtl)"/>
-    public async Task<CacheDictionarySetFieldResponse> DictionarySetAsync(string cacheName, string dictionaryName, string field, string value, CollectionTtl ttl = default(CollectionTtl))
+    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)"/>
+    public async Task<CacheDictionarySetFieldResponse> DictionarySetFieldAsync(string cacheName, string dictionaryName, string field, string value, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
@@ -226,11 +226,11 @@ public class SimpleCacheClient : ISimpleCacheClient
             return new CacheDictionarySetFieldResponse.Error(new InvalidArgumentException(e.Message));
         }
 
-        return await this.dataClient.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl);
+        return await this.dataClient.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl);
     }
 
-    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], CollectionTtl)"/>
-    public async Task<CacheDictionarySetFieldResponse> DictionarySetAsync(string cacheName, string dictionaryName, string field, byte[] value, CollectionTtl ttl = default(CollectionTtl))
+    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)"/>
+    public async Task<CacheDictionarySetFieldResponse> DictionarySetFieldAsync(string cacheName, string dictionaryName, string field, byte[] value, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
@@ -244,7 +244,7 @@ public class SimpleCacheClient : ISimpleCacheClient
             return new CacheDictionarySetFieldResponse.Error(new InvalidArgumentException(e.Message));
         }
 
-        return await this.dataClient.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl);
+        return await this.dataClient.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl);
     }
 
     /// <summary>
@@ -254,7 +254,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="dictionaryName">The dictionary to lookup.</param>
     /// <param name="field">The field in the dictionary to lookup.</param>
     /// <returns>Task representing the status of the get operation and the associated value.</returns>
-    public async Task<CacheDictionaryGetFieldResponse> DictionaryGetAsync(string cacheName, string dictionaryName, byte[] field)
+    public async Task<CacheDictionaryGetFieldResponse> DictionaryGetFieldAsync(string cacheName, string dictionaryName, byte[] field)
     {
         try
         {
@@ -267,11 +267,11 @@ public class SimpleCacheClient : ISimpleCacheClient
             return new CacheDictionaryGetFieldResponse.Error(new InvalidArgumentException(e.Message));
         }
 
-        return await this.dataClient.DictionaryGetAsync(cacheName, dictionaryName, field);
+        return await this.dataClient.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
     }
 
-    /// <inheritdoc cref="DictionaryGetAsync(string, string, byte[])"/>
-    public async Task<CacheDictionaryGetFieldResponse> DictionaryGetAsync(string cacheName, string dictionaryName, string field)
+    /// <inheritdoc cref="DictionaryGetFieldAsync(string, string, byte[])"/>
+    public async Task<CacheDictionaryGetFieldResponse> DictionaryGetFieldAsync(string cacheName, string dictionaryName, string field)
     {
         try
         {
@@ -284,19 +284,19 @@ public class SimpleCacheClient : ISimpleCacheClient
             return new CacheDictionaryGetFieldResponse.Error(new InvalidArgumentException(e.Message));
         }
 
-        return await this.dataClient.DictionaryGetAsync(cacheName, dictionaryName, field);
+        return await this.dataClient.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
     }
 
     /// <summary>
     /// Set several dictionary field-value pairs in the cache.
     /// </summary>
-    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
+    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
     /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
     /// <param name="dictionaryName">The dictionary to set.</param>
     /// <param name="items">The field-value pairs in the dictionary to set.</param>
     /// <param name="ttl">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    public async Task<CacheDictionarySetFieldsResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
@@ -310,11 +310,11 @@ public class SimpleCacheClient : ISimpleCacheClient
             return new CacheDictionarySetFieldsResponse.Error(new InvalidArgumentException(e.Message));
         }
 
-        return await this.dataClient.DictionarySetBatchAsync(cacheName, dictionaryName, items, ttl);
+        return await this.dataClient.DictionarySetFieldsAsync(cacheName, dictionaryName, items, ttl);
     }
 
-    /// <inheritdoc cref="DictionarySetBatchAsync(string, string, IEnumerable{KeyValuePair{byte[], byte[]}}, CollectionTtl)"/>
-    public async Task<CacheDictionarySetFieldsResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, string>> items, CollectionTtl ttl = default(CollectionTtl))
+    /// <inheritdoc cref="DictionarySetFieldsAsync(string, string, IEnumerable{KeyValuePair{byte[], byte[]}}, CollectionTtl)"/>
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, string>> items, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
@@ -328,11 +328,11 @@ public class SimpleCacheClient : ISimpleCacheClient
             return new CacheDictionarySetFieldsResponse.Error(new InvalidArgumentException(e.Message));
         }
 
-        return await this.dataClient.DictionarySetBatchAsync(cacheName, dictionaryName, items, ttl);
+        return await this.dataClient.DictionarySetFieldsAsync(cacheName, dictionaryName, items, ttl);
     }
 
-    /// <inheritdoc cref="DictionarySetBatchAsync(string, string, IEnumerable{KeyValuePair{byte[], byte[]}}, CollectionTtl)"/>
-    public async Task<CacheDictionarySetFieldsResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
+    /// <inheritdoc cref="DictionarySetFieldsAsync(string, string, IEnumerable{KeyValuePair{byte[], byte[]}}, CollectionTtl)"/>
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
@@ -346,7 +346,7 @@ public class SimpleCacheClient : ISimpleCacheClient
             return new CacheDictionarySetFieldsResponse.Error(new InvalidArgumentException(e.Message));
         }
 
-        return await this.dataClient.DictionarySetBatchAsync(cacheName, dictionaryName, items, ttl);
+        return await this.dataClient.DictionarySetFieldsAsync(cacheName, dictionaryName, items, ttl);
     }
 
     /// <summary>
@@ -356,7 +356,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <para>Incrementing a value that was not set using this method or not the string representation of an integer
     /// results in an error with <see cref="FailedPreconditionException"/>.</para>
     /// </summary>
-    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
+    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
     /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
     /// <param name="dictionaryName">The dictionary to set.</param>
     /// <param name="field"></param>
@@ -377,11 +377,11 @@ public class SimpleCacheClient : ISimpleCacheClient
     ///     }
     ///
     ///     // Reset the counter. Note we use the string representation of an integer.
-    ///     var setResponse = await client.DictionarySetAsync(cacheName, "my dictionary", "counter", "0");
+    ///     var setResponse = await client.DictionarySetFieldAsync(cacheName, "my dictionary", "counter", "0");
     ///     if (setResponse is CacheDictionarySetFieldResponse.Error) { /* handle error */ }
     ///
     ///     // Retrieve the counter. The integer is represented as a string.
-    ///     var getResponse = await client.DictionaryGetAsync(cacheName, "my dictionary", "counter");
+    ///     var getResponse = await client.DictionaryGetFieldAsync(cacheName, "my dictionary", "counter");
     ///     if (getResponse is CacheDictionaryGetFieldResponse.Hit getHit)
     ///     {
     ///         Console.WriteLine(getHit.String());
@@ -389,7 +389,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     ///     else if (getResponse is CacheDictionaryGetFieldResponse.Error) { /* handle error */ }
     ///
     ///     // Here we try incrementing a value that isn't an integer. This results in an error with <see cref="FailedPreconditionException"/>
-    ///     setResponse = await client.DictionarySetAsync(cacheName, "my dictionary", "counter", "0123ABC");
+    ///     setResponse = await client.DictionarySetFieldAsync(cacheName, "my dictionary", "counter", "0123ABC");
     ///     if (setResponse is CacheDictionarySetFieldResponse.Error) { /* handle error */ }
     ///
     ///     var incrementResponse = await client.DictionaryIncrementAsync(cacheName, "my dictionary", "counter", amount: 42);
@@ -422,7 +422,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="dictionaryName">The dictionary to lookup.</param>
     /// <param name="fields">The fields in the dictionary to lookup.</param>
     /// <returns>Task representing the status and associated value for each field.</returns>
-    public async Task<CacheDictionaryGetFieldsResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
+    public async Task<CacheDictionaryGetFieldsResponse> DictionaryGetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
     {
         try
         {
@@ -435,11 +435,11 @@ public class SimpleCacheClient : ISimpleCacheClient
         {
             return new CacheDictionaryGetFieldsResponse.Error(new InvalidArgumentException(e.Message));
         }
-        return await this.dataClient.DictionaryGetBatchAsync(cacheName, dictionaryName, fields);
+        return await this.dataClient.DictionaryGetFieldsAsync(cacheName, dictionaryName, fields);
     }
 
-    /// <inheritdoc cref="DictionaryGetBatchAsync(string, string, IEnumerable{byte[]})"/>
-    public async Task<CacheDictionaryGetFieldsResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<string> fields)
+    /// <inheritdoc cref="DictionaryGetFieldsAsync(string, string, IEnumerable{byte[]})"/>
+    public async Task<CacheDictionaryGetFieldsResponse> DictionaryGetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<string> fields)
     {
         try
         {
@@ -453,7 +453,7 @@ public class SimpleCacheClient : ISimpleCacheClient
             return new CacheDictionaryGetFieldsResponse.Error(new InvalidArgumentException(e.Message));
         }
 
-        return await this.dataClient.DictionaryGetBatchAsync(cacheName, dictionaryName, fields);
+        return await this.dataClient.DictionaryGetFieldsAsync(cacheName, dictionaryName, fields);
     }
 
     /// <summary>
@@ -596,13 +596,13 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// After this operation, the set will contain the union
     /// of the element passed in and the elements of the set.
     /// </summary>
-    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
+    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
     /// <param name="cacheName">Name of the cache to store the set in.</param>
     /// <param name="setName">The set to add the element to.</param>
     /// <param name="element">The data to add to the set.</param>
     /// <param name="ttl">TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    public async Task<CacheSetAddElementResponse> SetAddAsync(string cacheName, string setName, byte[] element, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheSetAddElementResponse> SetAddElementAsync(string cacheName, string setName, byte[] element, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
@@ -615,11 +615,11 @@ public class SimpleCacheClient : ISimpleCacheClient
         {
             return new CacheSetAddElementResponse.Error(new InvalidArgumentException(e.Message));
         }
-        return await this.dataClient.SetAddAsync(cacheName, setName, element, ttl);
+        return await this.dataClient.SetAddElementAsync(cacheName, setName, element, ttl);
     }
 
-    /// <inheritdoc cref="SetAddAsync(string, string, byte[], CollectionTtl)"/>
-    public async Task<CacheSetAddElementResponse> SetAddAsync(string cacheName, string setName, string element, CollectionTtl ttl = default(CollectionTtl))
+    /// <inheritdoc cref="SetAddElementAsync(string, string, byte[], CollectionTtl)"/>
+    public async Task<CacheSetAddElementResponse> SetAddElementAsync(string cacheName, string setName, string element, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
@@ -632,7 +632,7 @@ public class SimpleCacheClient : ISimpleCacheClient
             return new CacheSetAddElementResponse.Error(new InvalidArgumentException(e.Message));
         }
 
-        return await this.dataClient.SetAddAsync(cacheName, setName, element, ttl);
+        return await this.dataClient.SetAddElementAsync(cacheName, setName, element, ttl);
     }
 
     /// <summary>
@@ -641,13 +641,13 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// After this operation, the set will contain the union
     /// of the elements passed in and the elements of the set.
     /// </summary>
-    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
+    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
     /// <param name="cacheName">Name of the cache to store the set in.</param>
     /// <param name="setName">The set to add elements to.</param>
     /// <param name="elements">The data to add to the set.</param>
     /// <param name="ttl">TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    public async Task<CacheSetAddElementsResponse> SetAddBatchAsync(string cacheName, string setName, IEnumerable<byte[]> elements, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheSetAddElementsResponse> SetAddElementsAsync(string cacheName, string setName, IEnumerable<byte[]> elements, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
@@ -661,11 +661,11 @@ public class SimpleCacheClient : ISimpleCacheClient
         {
             return new CacheSetAddElementsResponse.Error(new InvalidArgumentException(e.Message));
         }
-        return await this.dataClient.SetAddBatchAsync(cacheName, setName, elements, ttl);
+        return await this.dataClient.SetAddElementsAsync(cacheName, setName, elements, ttl);
     }
 
-    /// <inheritdoc cref="SetAddBatchAsync(string, string, IEnumerable{byte[]}, CollectionTtl)"/>
-    public async Task<CacheSetAddElementsResponse> SetAddBatchAsync(string cacheName, string setName, IEnumerable<string> elements, CollectionTtl ttl = default(CollectionTtl))
+    /// <inheritdoc cref="SetAddElementsAsync(string, string, IEnumerable{byte[]}, CollectionTtl)"/>
+    public async Task<CacheSetAddElementsResponse> SetAddElementsAsync(string cacheName, string setName, IEnumerable<string> elements, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
@@ -680,7 +680,7 @@ public class SimpleCacheClient : ISimpleCacheClient
             return new CacheSetAddElementsResponse.Error(new InvalidArgumentException(e.Message));
         }
 
-        return await this.dataClient.SetAddBatchAsync(cacheName, setName, elements, ttl);
+        return await this.dataClient.SetAddElementsAsync(cacheName, setName, elements, ttl);
     }
 
     /// <summary>
@@ -817,7 +817,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <summary>
     /// Push a value to the beginning of a list.
     /// </summary>
-    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
+    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
     /// <param name="cacheName">Name of the cache to store the list in.</param>
     /// <param name="listName">The list to push the value on.</param>
     /// <param name="value">The value to push to the front of the list.</param>
@@ -870,7 +870,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <summary>
     /// Push a value to the end of a list.
     /// </summary>
-    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
+    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
     /// <param name="cacheName">Name of the cache to store the list in.</param>
     /// <param name="listName">The list to push the value on.</param>
     /// <param name="value">The value to push to the back of the list.</param>

--- a/src/Momento.Sdk.Incubating/SimpleCacheClient.cs
+++ b/src/Momento.Sdk.Incubating/SimpleCacheClient.cs
@@ -194,7 +194,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="value">The value to be stored.</param>
     /// <param name="ttl">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, byte[] field, byte[] value, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldResponse> DictionarySetAsync(string cacheName, string dictionaryName, byte[] field, byte[] value, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
@@ -205,14 +205,14 @@ public class SimpleCacheClient : ISimpleCacheClient
         }
         catch (ArgumentNullException e)
         {
-            return new CacheDictionarySetResponse.Error(new InvalidArgumentException(e.Message));
+            return new CacheDictionarySetFieldResponse.Error(new InvalidArgumentException(e.Message));
         }
 
         return await this.dataClient.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl);
     }
 
     /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], CollectionTtl)"/>
-    public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, string field, string value, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldResponse> DictionarySetAsync(string cacheName, string dictionaryName, string field, string value, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
@@ -223,14 +223,14 @@ public class SimpleCacheClient : ISimpleCacheClient
         }
         catch (ArgumentNullException e)
         {
-            return new CacheDictionarySetResponse.Error(new InvalidArgumentException(e.Message));
+            return new CacheDictionarySetFieldResponse.Error(new InvalidArgumentException(e.Message));
         }
 
         return await this.dataClient.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl);
     }
 
     /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], CollectionTtl)"/>
-    public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, string field, byte[] value, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldResponse> DictionarySetAsync(string cacheName, string dictionaryName, string field, byte[] value, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
@@ -241,7 +241,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         }
         catch (ArgumentNullException e)
         {
-            return new CacheDictionarySetResponse.Error(new InvalidArgumentException(e.Message));
+            return new CacheDictionarySetFieldResponse.Error(new InvalidArgumentException(e.Message));
         }
 
         return await this.dataClient.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl);
@@ -254,7 +254,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="dictionaryName">The dictionary to lookup.</param>
     /// <param name="field">The field in the dictionary to lookup.</param>
     /// <returns>Task representing the status of the get operation and the associated value.</returns>
-    public async Task<CacheDictionaryGetResponse> DictionaryGetAsync(string cacheName, string dictionaryName, byte[] field)
+    public async Task<CacheDictionaryGetFieldResponse> DictionaryGetAsync(string cacheName, string dictionaryName, byte[] field)
     {
         try
         {
@@ -264,14 +264,14 @@ public class SimpleCacheClient : ISimpleCacheClient
         }
         catch (ArgumentNullException e)
         {
-            return new CacheDictionaryGetResponse.Error(new InvalidArgumentException(e.Message));
+            return new CacheDictionaryGetFieldResponse.Error(new InvalidArgumentException(e.Message));
         }
 
         return await this.dataClient.DictionaryGetAsync(cacheName, dictionaryName, field);
     }
 
     /// <inheritdoc cref="DictionaryGetAsync(string, string, byte[])"/>
-    public async Task<CacheDictionaryGetResponse> DictionaryGetAsync(string cacheName, string dictionaryName, string field)
+    public async Task<CacheDictionaryGetFieldResponse> DictionaryGetAsync(string cacheName, string dictionaryName, string field)
     {
         try
         {
@@ -281,7 +281,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         }
         catch (ArgumentNullException e)
         {
-            return new CacheDictionaryGetResponse.Error(new InvalidArgumentException(e.Message));
+            return new CacheDictionaryGetFieldResponse.Error(new InvalidArgumentException(e.Message));
         }
 
         return await this.dataClient.DictionaryGetAsync(cacheName, dictionaryName, field);
@@ -296,7 +296,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="items">The field-value pairs in the dictionary to set.</param>
     /// <param name="ttl">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    public async Task<CacheDictionarySetBatchResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
@@ -307,14 +307,14 @@ public class SimpleCacheClient : ISimpleCacheClient
         }
         catch (ArgumentNullException e)
         {
-            return new CacheDictionarySetBatchResponse.Error(new InvalidArgumentException(e.Message));
+            return new CacheDictionarySetFieldsResponse.Error(new InvalidArgumentException(e.Message));
         }
 
         return await this.dataClient.DictionarySetBatchAsync(cacheName, dictionaryName, items, ttl);
     }
 
     /// <inheritdoc cref="DictionarySetBatchAsync(string, string, IEnumerable{KeyValuePair{byte[], byte[]}}, CollectionTtl)"/>
-    public async Task<CacheDictionarySetBatchResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, string>> items, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, string>> items, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
@@ -325,14 +325,14 @@ public class SimpleCacheClient : ISimpleCacheClient
         }
         catch (ArgumentNullException e)
         {
-            return new CacheDictionarySetBatchResponse.Error(new InvalidArgumentException(e.Message));
+            return new CacheDictionarySetFieldsResponse.Error(new InvalidArgumentException(e.Message));
         }
 
         return await this.dataClient.DictionarySetBatchAsync(cacheName, dictionaryName, items, ttl);
     }
 
     /// <inheritdoc cref="DictionarySetBatchAsync(string, string, IEnumerable{KeyValuePair{byte[], byte[]}}, CollectionTtl)"/>
-    public async Task<CacheDictionarySetBatchResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
@@ -343,7 +343,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         }
         catch (ArgumentNullException e)
         {
-            return new CacheDictionarySetBatchResponse.Error(new InvalidArgumentException(e.Message));
+            return new CacheDictionarySetFieldsResponse.Error(new InvalidArgumentException(e.Message));
         }
 
         return await this.dataClient.DictionarySetBatchAsync(cacheName, dictionaryName, items, ttl);
@@ -378,19 +378,19 @@ public class SimpleCacheClient : ISimpleCacheClient
     ///
     ///     // Reset the counter. Note we use the string representation of an integer.
     ///     var setResponse = await client.DictionarySetAsync(cacheName, "my dictionary", "counter", "0");
-    ///     if (setResponse is CacheDictionarySetResponse.Error) { /* handle error */ }
+    ///     if (setResponse is CacheDictionarySetFieldResponse.Error) { /* handle error */ }
     ///
     ///     // Retrieve the counter. The integer is represented as a string.
     ///     var getResponse = await client.DictionaryGetAsync(cacheName, "my dictionary", "counter");
-    ///     if (getResponse is CacheDictionaryGetResponse.Hit getHit)
+    ///     if (getResponse is CacheDictionaryGetFieldResponse.Hit getHit)
     ///     {
     ///         Console.WriteLine(getHit.String());
     ///     }
-    ///     else if (getResponse is CacheDictionaryGetResponse.Error) { /* handle error */ }
+    ///     else if (getResponse is CacheDictionaryGetFieldResponse.Error) { /* handle error */ }
     ///
     ///     // Here we try incrementing a value that isn't an integer. This results in an error with <see cref="FailedPreconditionException"/>
     ///     setResponse = await client.DictionarySetAsync(cacheName, "my dictionary", "counter", "0123ABC");
-    ///     if (setResponse is CacheDictionarySetResponse.Error) { /* handle error */ }
+    ///     if (setResponse is CacheDictionarySetFieldResponse.Error) { /* handle error */ }
     ///
     ///     var incrementResponse = await client.DictionaryIncrementAsync(cacheName, "my dictionary", "counter", amount: 42);
     ///     if (incrementResponse is CacheDictionaryIncrementResponse.Error badIncrement)
@@ -422,7 +422,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="dictionaryName">The dictionary to lookup.</param>
     /// <param name="fields">The fields in the dictionary to lookup.</param>
     /// <returns>Task representing the status and associated value for each field.</returns>
-    public async Task<CacheDictionaryGetBatchResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
+    public async Task<CacheDictionaryGetFieldsResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
     {
         try
         {
@@ -433,13 +433,13 @@ public class SimpleCacheClient : ISimpleCacheClient
         }
         catch (ArgumentNullException e)
         {
-            return new CacheDictionaryGetBatchResponse.Error(new InvalidArgumentException(e.Message));
+            return new CacheDictionaryGetFieldsResponse.Error(new InvalidArgumentException(e.Message));
         }
         return await this.dataClient.DictionaryGetBatchAsync(cacheName, dictionaryName, fields);
     }
 
     /// <inheritdoc cref="DictionaryGetBatchAsync(string, string, IEnumerable{byte[]})"/>
-    public async Task<CacheDictionaryGetBatchResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<string> fields)
+    public async Task<CacheDictionaryGetFieldsResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<string> fields)
     {
         try
         {
@@ -450,7 +450,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         }
         catch (ArgumentNullException e)
         {
-            return new CacheDictionaryGetBatchResponse.Error(new InvalidArgumentException(e.Message));
+            return new CacheDictionaryGetFieldsResponse.Error(new InvalidArgumentException(e.Message));
         }
 
         return await this.dataClient.DictionaryGetBatchAsync(cacheName, dictionaryName, fields);
@@ -602,7 +602,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="element">The data to add to the set.</param>
     /// <param name="ttl">TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    public async Task<CacheSetAddResponse> SetAddAsync(string cacheName, string setName, byte[] element, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheSetAddElementResponse> SetAddAsync(string cacheName, string setName, byte[] element, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
@@ -613,13 +613,13 @@ public class SimpleCacheClient : ISimpleCacheClient
 
         catch (ArgumentNullException e)
         {
-            return new CacheSetAddResponse.Error(new InvalidArgumentException(e.Message));
+            return new CacheSetAddElementResponse.Error(new InvalidArgumentException(e.Message));
         }
         return await this.dataClient.SetAddAsync(cacheName, setName, element, ttl);
     }
 
     /// <inheritdoc cref="SetAddAsync(string, string, byte[], CollectionTtl)"/>
-    public async Task<CacheSetAddResponse> SetAddAsync(string cacheName, string setName, string element, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheSetAddElementResponse> SetAddAsync(string cacheName, string setName, string element, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
@@ -629,7 +629,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         }
         catch (ArgumentNullException e)
         {
-            return new CacheSetAddResponse.Error(new InvalidArgumentException(e.Message));
+            return new CacheSetAddElementResponse.Error(new InvalidArgumentException(e.Message));
         }
 
         return await this.dataClient.SetAddAsync(cacheName, setName, element, ttl);
@@ -647,7 +647,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="elements">The data to add to the set.</param>
     /// <param name="ttl">TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    public async Task<CacheSetAddBatchResponse> SetAddBatchAsync(string cacheName, string setName, IEnumerable<byte[]> elements, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheSetAddElementsResponse> SetAddBatchAsync(string cacheName, string setName, IEnumerable<byte[]> elements, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
@@ -659,13 +659,13 @@ public class SimpleCacheClient : ISimpleCacheClient
 
         catch (ArgumentNullException e)
         {
-            return new CacheSetAddBatchResponse.Error(new InvalidArgumentException(e.Message));
+            return new CacheSetAddElementsResponse.Error(new InvalidArgumentException(e.Message));
         }
         return await this.dataClient.SetAddBatchAsync(cacheName, setName, elements, ttl);
     }
 
     /// <inheritdoc cref="SetAddBatchAsync(string, string, IEnumerable{byte[]}, CollectionTtl)"/>
-    public async Task<CacheSetAddBatchResponse> SetAddBatchAsync(string cacheName, string setName, IEnumerable<string> elements, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheSetAddElementsResponse> SetAddBatchAsync(string cacheName, string setName, IEnumerable<string> elements, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
@@ -677,7 +677,7 @@ public class SimpleCacheClient : ISimpleCacheClient
 
         catch (ArgumentNullException e)
         {
-            return new CacheSetAddBatchResponse.Error(new InvalidArgumentException(e.Message));
+            return new CacheSetAddElementsResponse.Error(new InvalidArgumentException(e.Message));
         }
 
         return await this.dataClient.SetAddBatchAsync(cacheName, setName, elements, ttl);

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
@@ -16,11 +16,11 @@ public class DictionaryTest : TestBase
     [InlineData(null, "my-dictionary", new byte[] { 0x00 })]
     [InlineData("cache", null, new byte[] { 0x00 })]
     [InlineData("cache", "my-dictionary", null)]
-    public async Task DictionaryGetAsync_NullChecksFieldIsByteArray_IsError(string cacheName, string dictionaryName, byte[] field)
+    public async Task DictionaryGetFieldAsync_NullChecksFieldIsByteArray_IsError(string cacheName, string dictionaryName, byte[] field)
     {
-        CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetResponse.Error)response).ErrorCode);
+        CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetFieldResponse.Error)response).ErrorCode);
     }
 
     [Theory]
@@ -28,20 +28,20 @@ public class DictionaryTest : TestBase
     [InlineData("cache", null, new byte[] { 0x00 }, new byte[] { 0x00 })]
     [InlineData("cache", "my-dictionary", null, new byte[] { 0x00 })]
     [InlineData("cache", "my-dictionary", new byte[] { 0x00 }, null)]
-    public async Task DictionarySetAsync_NullChecksFieldIsByteArrayValueIsByteArray_IsError(string cacheName, string dictionaryName, byte[] field, byte[] value)
+    public async Task DictionarySetFieldAsync_NullChecksFieldIsByteArrayValueIsByteArray_IsError(string cacheName, string dictionaryName, byte[] field, byte[] value)
     {
-        CacheDictionarySetResponse response = await client.DictionarySetAsync(cacheName, dictionaryName, field, value);
-        Assert.True(response is CacheDictionarySetResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetResponse.Error)response).ErrorCode);
+        CacheDictionarySetFieldResponse response = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value);
+        Assert.True(response is CacheDictionarySetFieldResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetFieldResponse.Error)response).ErrorCode);
     }
 
     [Fact]
-    public async Task DictionaryGetAsync_FieldIsByteArray_DictionaryIsMissing()
+    public async Task DictionaryGetFieldAsync_FieldIsByteArray_DictionaryIsMissing()
     {
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidByteArray();
-        CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
+        CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -51,10 +51,10 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidByteArray();
         var value = Utils.NewGuidByteArray();
 
-        await client.DictionarySetAsync(cacheName, dictionaryName, field, value);
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value);
 
-        CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
+        CacheDictionaryGetFieldResponse getResponse = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(getResponse is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {getResponse}");
     }
 
     [Fact]
@@ -64,12 +64,12 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidByteArray();
         var value = Utils.NewGuidByteArray();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value);
-        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
+        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value);
+        Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
 
         var otherField = Utils.NewGuidByteArray();
-        CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, otherField);
-        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
+        CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, otherField);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -79,16 +79,16 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidByteArray();
         var value = Utils.NewGuidByteArray();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
-        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
+        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(100);
 
-        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
-        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
+        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
+        Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(4900);
 
-        CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
+        CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -98,15 +98,15 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidByteArray();
         var value = Utils.NewGuidByteArray();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(2)));
-        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
-        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
-        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
+        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(2)));
+        Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
+        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(2000);
 
-        CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
-        Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).ValueByteArray);
+        CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {response}");
+        Assert.Equal(value, ((CacheDictionaryGetFieldResponse.Hit)response).ValueByteArray);
     }
 
     [Theory]
@@ -141,9 +141,9 @@ public class DictionaryTest : TestBase
         successResponse = (CacheDictionaryIncrementResponse.Success)incrementResponse;
         Assert.Equal(-1000, successResponse.Value);
 
-        CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, fieldName);
-        Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
-        var hitResponse = (CacheDictionaryGetResponse.Hit)getResponse;
+        CacheDictionaryGetFieldResponse getResponse = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, fieldName);
+        Assert.True(getResponse is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {getResponse}");
+        var hitResponse = (CacheDictionaryGetFieldResponse.Hit)getResponse;
         Assert.Equal("-1000", hitResponse.ValueString);
     }
 
@@ -159,9 +159,9 @@ public class DictionaryTest : TestBase
         Assert.True(resp is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {resp}");
         await Task.Delay(2000);
 
-        CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
-        Assert.Equal("2", ((CacheDictionaryGetResponse.Hit)response).ValueString);
+        CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {response}");
+        Assert.Equal("2", ((CacheDictionaryGetFieldResponse.Hit)response).ValueString);
     }
 
     [Fact]
@@ -178,8 +178,8 @@ public class DictionaryTest : TestBase
         Assert.True(resp is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {resp}");
         await Task.Delay(4900);
 
-        CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
+        CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -189,7 +189,7 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
 
         // Set field
-        await client.DictionarySetAsync(cacheName, dictionaryName, field, "10");
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, "10");
         CacheDictionaryIncrementResponse incrementResponse = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, amount: 0);
         Assert.True(incrementResponse is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {incrementResponse}");
         var successResponse = (CacheDictionaryIncrementResponse.Success)incrementResponse;
@@ -201,7 +201,7 @@ public class DictionaryTest : TestBase
         Assert.Equal(100, successResponse.Value);
 
         // Reset field
-        await client.DictionarySetAsync(cacheName, dictionaryName, field, "0");
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, "0");
         incrementResponse = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, amount: 0);
         Assert.True(incrementResponse is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {incrementResponse}");
         successResponse = (CacheDictionaryIncrementResponse.Success)incrementResponse;
@@ -214,8 +214,8 @@ public class DictionaryTest : TestBase
         var dictionaryName = Utils.NewGuidString();
         var fieldName = Utils.NewGuidString();
 
-        var setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, fieldName, "abcxyz");
-        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
+        var setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, fieldName, "abcxyz");
+        Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
 
         var dictionaryIncrementResponse = await client.DictionaryIncrementAsync(cacheName, dictionaryName, fieldName);
         Assert.True(dictionaryIncrementResponse is CacheDictionaryIncrementResponse.Error, $"Unexpected response: {dictionaryIncrementResponse}");
@@ -226,11 +226,11 @@ public class DictionaryTest : TestBase
     [InlineData(null, "my-dictionary", "my-field")]
     [InlineData("cache", null, "my-field")]
     [InlineData("cache", "my-dictionary", null)]
-    public async Task DictionaryGetAsync_NullChecksFieldIsString_IsError(string cacheName, string dictionaryName, string field)
+    public async Task DictionaryGetFieldAsync_NullChecksFieldIsString_IsError(string cacheName, string dictionaryName, string field)
     {
-        CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetResponse.Error)response).ErrorCode);
+        CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetFieldResponse.Error)response).ErrorCode);
     }
 
     [Theory]
@@ -238,20 +238,20 @@ public class DictionaryTest : TestBase
     [InlineData("cache", null, "my-field", "my-value")]
     [InlineData("cache", "my-dictionary", null, "my-value")]
     [InlineData("cache", "my-dictionary", "my-field", null)]
-    public async Task DictionarySetAsync_NullChecksFieldIsStringValueIsString_IsError(string cacheName, string dictionaryName, string field, string value)
+    public async Task DictionarySetFieldAsync_NullChecksFieldIsStringValueIsString_IsError(string cacheName, string dictionaryName, string field, string value)
     {
-        CacheDictionarySetResponse response = await client.DictionarySetAsync(cacheName, dictionaryName, field, value);
-        Assert.True(response is CacheDictionarySetResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetResponse.Error)response).ErrorCode);
+        CacheDictionarySetFieldResponse response = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value);
+        Assert.True(response is CacheDictionarySetFieldResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetFieldResponse.Error)response).ErrorCode);
     }
 
     [Fact]
-    public async Task DictionaryGetAsync_FieldIsString_DictionaryIsMissing()
+    public async Task DictionaryGetFieldAsync_FieldIsString_DictionaryIsMissing()
     {
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidString();
-        CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
+        CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -261,11 +261,11 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        CacheDictionarySetResponse response = await client.DictionarySetAsync(cacheName, dictionaryName, field, value);
-        Assert.True(response is CacheDictionarySetResponse.Success, $"Unexpected response: {response}");
+        CacheDictionarySetFieldResponse response = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value);
+        Assert.True(response is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {response}");
 
-        CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
+        CacheDictionaryGetFieldResponse getResponse = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(getResponse is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {getResponse}");
     }
 
     [Fact]
@@ -275,12 +275,12 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value);
-        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
+        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value);
+        Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
 
         var otherField = Utils.NewGuidString();
-        CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, otherField);
-        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
+        CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, otherField);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -290,16 +290,16 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)));
-        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
+        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)));
+        Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(100);
 
-        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
-        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
+        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
+        Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(4900);
 
-        CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
+        CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -309,15 +309,15 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
-        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
-        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
-        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
+        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
+        Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
+        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(2000);
 
-        CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
-        Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).ValueString);
+        CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {response}");
+        Assert.Equal(value, ((CacheDictionaryGetFieldResponse.Hit)response).ValueString);
     }
 
     [Theory]
@@ -325,11 +325,11 @@ public class DictionaryTest : TestBase
     [InlineData("cache", null, "my-field", new byte[] { 0x00 })]
     [InlineData("cache", "my-dictionary", null, new byte[] { 0x00 })]
     [InlineData("cache", "my-dictionary", "my-field", null)]
-    public async Task DictionarySetAsync_NullChecksFieldIsStringValueIsByteArray_IsError(string cacheName, string dictionaryName, string field, byte[] value)
+    public async Task DictionarySetFieldAsync_NullChecksFieldIsStringValueIsByteArray_IsError(string cacheName, string dictionaryName, string field, byte[] value)
     {
-        CacheDictionarySetResponse response = await client.DictionarySetAsync(cacheName, dictionaryName, field, value);
-        Assert.True(response is CacheDictionarySetResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetResponse.Error)response).ErrorCode);
+        CacheDictionarySetFieldResponse response = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value);
+        Assert.True(response is CacheDictionarySetFieldResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetFieldResponse.Error)response).ErrorCode);
     }
 
     [Fact]
@@ -339,11 +339,11 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value);
-        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
+        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value);
+        Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
 
-        CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
+        CacheDictionaryGetFieldResponse getResponse = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(getResponse is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {getResponse}");
     }
 
     [Fact]
@@ -353,16 +353,16 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)));
-        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
+        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)));
+        Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(100);
 
-        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
-        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
+        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
+        Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(4900);
 
-        CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
+        CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -372,40 +372,40 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        CacheDictionarySetResponse setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
-        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
-        setResponse = await client.DictionarySetAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
-        Assert.True(setResponse is CacheDictionarySetResponse.Success, $"Unexpected response: {setResponse}");
+        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
+        Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
+        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(2000);
 
-        CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
-        Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).ValueByteArray);
+        CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {response}");
+        Assert.Equal(value, ((CacheDictionaryGetFieldResponse.Hit)response).ValueByteArray);
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_NullChecksFieldIsByteArrayValueIsByteArray_IsError()
+    public async Task DictionarySetFieldsAsync_NullChecksFieldIsByteArrayValueIsByteArray_IsError()
     {
         var dictionaryName = Utils.NewGuidString();
         var dictionary = new Dictionary<byte[], byte[]>();
-        CacheDictionarySetBatchResponse response = await client.DictionarySetBatchAsync(null!, dictionaryName, dictionary);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
-        response = await client.DictionarySetBatchAsync(cacheName, null!, dictionary);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
-        response = await client.DictionarySetBatchAsync(cacheName, dictionaryName, (IEnumerable<KeyValuePair<byte[], byte[]>>)null!);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
+        CacheDictionarySetFieldsResponse response = await client.DictionarySetFieldsAsync(null!, dictionaryName, dictionary);
+        Assert.True(response is CacheDictionarySetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetFieldsResponse.Error)response).ErrorCode);
+        response = await client.DictionarySetFieldsAsync(cacheName, null!, dictionary);
+        Assert.True(response is CacheDictionarySetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetFieldsResponse.Error)response).ErrorCode);
+        response = await client.DictionarySetFieldsAsync(cacheName, dictionaryName, (IEnumerable<KeyValuePair<byte[], byte[]>>)null!);
+        Assert.True(response is CacheDictionarySetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetFieldsResponse.Error)response).ErrorCode);
 
         dictionary[Utils.NewGuidByteArray()] = null!;
-        response = await client.DictionarySetBatchAsync(cacheName, dictionaryName, dictionary);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
+        response = await client.DictionarySetFieldsAsync(cacheName, dictionaryName, dictionary);
+        Assert.True(response is CacheDictionarySetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetFieldsResponse.Error)response).ErrorCode);
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_FieldsAreByteArrayValuesAreByteArray_HappyPath()
+    public async Task DictionarySetFieldsAsync_FieldsAreByteArrayValuesAreByteArray_HappyPath()
     {
         var dictionaryName = Utils.NewGuidString();
         var field1 = Utils.NewGuidByteArray();
@@ -415,75 +415,75 @@ public class DictionaryTest : TestBase
 
         var items = new Dictionary<byte[], byte[]>() { { field1, value1 }, { field2, value2 } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, items, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, items, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
 
-        CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field1);
-        Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
-        Assert.Equal(value1, ((CacheDictionaryGetResponse.Hit)getResponse).ValueByteArray);
+        CacheDictionaryGetFieldResponse getResponse = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1);
+        Assert.True(getResponse is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {getResponse}");
+        Assert.Equal(value1, ((CacheDictionaryGetFieldResponse.Hit)getResponse).ValueByteArray);
 
-        getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field2);
-        Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
-        Assert.Equal(value2, ((CacheDictionaryGetResponse.Hit)getResponse).ValueByteArray);
+        getResponse = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field2);
+        Assert.True(getResponse is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {getResponse}");
+        Assert.Equal(value2, ((CacheDictionaryGetFieldResponse.Hit)getResponse).ValueByteArray);
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_FieldsAreByteArrayValuesAreByteArray_NoRefreshTtl()
+    public async Task DictionarySetFieldsAsync_FieldsAreByteArrayValuesAreByteArray_NoRefreshTtl()
     {
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidByteArray();
         var value = Utils.NewGuidByteArray();
         var content = new Dictionary<byte[], byte[]>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)));
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)));
         await Task.Delay(100);
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(4900);
 
-        CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
+        CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_FieldsAreByteArrayValuesAreByteArray_RefreshTtl()
+    public async Task DictionarySetFieldsAsync_FieldsAreByteArrayValuesAreByteArray_RefreshTtl()
     {
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidByteArray();
         var value = Utils.NewGuidByteArray();
         var content = new Dictionary<byte[], byte[]>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
         await Task.Delay(2000);
 
-        CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
-        Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).ValueByteArray);
+        CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {response}");
+        Assert.Equal(value, ((CacheDictionaryGetFieldResponse.Hit)response).ValueByteArray);
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_NullChecksFieldsAreStringValuesAreString_IsError()
+    public async Task DictionarySetFieldsAsync_NullChecksFieldsAreStringValuesAreString_IsError()
     {
         var dictionaryName = Utils.NewGuidString();
         var dictionary = new Dictionary<string, string>();
-        CacheDictionarySetBatchResponse response = await client.DictionarySetBatchAsync(null!, dictionaryName, dictionary);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
-        response = await client.DictionarySetBatchAsync(cacheName, null!, dictionary);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
-        response = await client.DictionarySetBatchAsync(cacheName, dictionaryName, (IEnumerable<KeyValuePair<string, string>>)null!);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
+        CacheDictionarySetFieldsResponse response = await client.DictionarySetFieldsAsync(null!, dictionaryName, dictionary);
+        Assert.True(response is CacheDictionarySetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetFieldsResponse.Error)response).ErrorCode);
+        response = await client.DictionarySetFieldsAsync(cacheName, null!, dictionary);
+        Assert.True(response is CacheDictionarySetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetFieldsResponse.Error)response).ErrorCode);
+        response = await client.DictionarySetFieldsAsync(cacheName, dictionaryName, (IEnumerable<KeyValuePair<string, string>>)null!);
+        Assert.True(response is CacheDictionarySetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetFieldsResponse.Error)response).ErrorCode);
 
         dictionary[Utils.NewGuidString()] = null!;
-        response = await client.DictionarySetBatchAsync(cacheName, dictionaryName, dictionary);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
+        response = await client.DictionarySetFieldsAsync(cacheName, dictionaryName, dictionary);
+        Assert.True(response is CacheDictionarySetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetFieldsResponse.Error)response).ErrorCode);
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_FieldsAreStringValuesAreString_HappyPath()
+    public async Task DictionarySetFieldsAsync_FieldsAreStringValuesAreString_HappyPath()
     {
         var dictionaryName = Utils.NewGuidString();
         var field1 = Utils.NewGuidString();
@@ -493,75 +493,75 @@ public class DictionaryTest : TestBase
 
         var items = new Dictionary<string, string>() { { field1, value1 }, { field2, value2 } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, items);
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, items);
 
-        CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field1);
-        Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
-        Assert.Equal(value1, ((CacheDictionaryGetResponse.Hit)getResponse).ValueString);
+        CacheDictionaryGetFieldResponse getResponse = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1);
+        Assert.True(getResponse is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {getResponse}");
+        Assert.Equal(value1, ((CacheDictionaryGetFieldResponse.Hit)getResponse).ValueString);
 
-        getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field2);
-        Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
-        Assert.Equal(value2, ((CacheDictionaryGetResponse.Hit)getResponse).ValueString);
+        getResponse = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field2);
+        Assert.True(getResponse is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {getResponse}");
+        Assert.Equal(value2, ((CacheDictionaryGetFieldResponse.Hit)getResponse).ValueString);
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_FieldsAreStringValuesAreString_NoRefreshTtl()
+    public async Task DictionarySetFieldsAsync_FieldsAreStringValuesAreString_NoRefreshTtl()
     {
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidString();
         var content = new Dictionary<string, string>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)));
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)));
         await Task.Delay(100);
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(4900);
 
-        CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
+        CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_FieldsAreStringValuesAreString_RefreshTtl()
+    public async Task DictionarySetFieldsAsync_FieldsAreStringValuesAreString_RefreshTtl()
     {
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidString();
         var content = new Dictionary<string, string>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
         await Task.Delay(2000);
 
-        CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
-        Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).ValueString);
+        CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {response}");
+        Assert.Equal(value, ((CacheDictionaryGetFieldResponse.Hit)response).ValueString);
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_NullChecksFieldsAreStringValuesAreByteArray_IsError()
+    public async Task DictionarySetFieldsAsync_NullChecksFieldsAreStringValuesAreByteArray_IsError()
     {
         var dictionaryName = Utils.NewGuidString();
         var dictionary = new Dictionary<string, string>();
-        CacheDictionarySetBatchResponse response = await client.DictionarySetBatchAsync(null!, dictionaryName, dictionary);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
-        response = await client.DictionarySetBatchAsync(cacheName, null!, dictionary);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
-        response = await client.DictionarySetBatchAsync(cacheName, dictionaryName, (IEnumerable<KeyValuePair<string, byte[]>>)null!);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
+        CacheDictionarySetFieldsResponse response = await client.DictionarySetFieldsAsync(null!, dictionaryName, dictionary);
+        Assert.True(response is CacheDictionarySetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetFieldsResponse.Error)response).ErrorCode);
+        response = await client.DictionarySetFieldsAsync(cacheName, null!, dictionary);
+        Assert.True(response is CacheDictionarySetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetFieldsResponse.Error)response).ErrorCode);
+        response = await client.DictionarySetFieldsAsync(cacheName, dictionaryName, (IEnumerable<KeyValuePair<string, byte[]>>)null!);
+        Assert.True(response is CacheDictionarySetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetFieldsResponse.Error)response).ErrorCode);
 
         dictionary[Utils.NewGuidString()] = null!;
-        response = await client.DictionarySetBatchAsync(cacheName, dictionaryName, dictionary);
-        Assert.True(response is CacheDictionarySetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetBatchResponse.Error)response).ErrorCode);
+        response = await client.DictionarySetFieldsAsync(cacheName, dictionaryName, dictionary);
+        Assert.True(response is CacheDictionarySetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionarySetFieldsResponse.Error)response).ErrorCode);
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_FieldsAreStringValuesAreByteArray_HappyPath()
+    public async Task DictionarySetFieldsAsync_FieldsAreStringValuesAreByteArray_HappyPath()
     {
         var dictionaryName = Utils.NewGuidString();
         var field1 = Utils.NewGuidString();
@@ -571,88 +571,88 @@ public class DictionaryTest : TestBase
 
         var items = new Dictionary<string, byte[]>() { { field1, value1 }, { field2, value2 } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, items);
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, items);
 
-        CacheDictionaryGetResponse getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field1);
-        Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
-        Assert.Equal(value1, ((CacheDictionaryGetResponse.Hit)getResponse).ValueByteArray);
+        CacheDictionaryGetFieldResponse getResponse = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1);
+        Assert.True(getResponse is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {getResponse}");
+        Assert.Equal(value1, ((CacheDictionaryGetFieldResponse.Hit)getResponse).ValueByteArray);
 
-        getResponse = await client.DictionaryGetAsync(cacheName, dictionaryName, field2);
-        Assert.True(getResponse is CacheDictionaryGetResponse.Hit, $"Unexpected response: {getResponse}");
-        Assert.Equal(value2, ((CacheDictionaryGetResponse.Hit)getResponse).ValueByteArray);
+        getResponse = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field2);
+        Assert.True(getResponse is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {getResponse}");
+        Assert.Equal(value2, ((CacheDictionaryGetFieldResponse.Hit)getResponse).ValueByteArray);
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_FieldsAreStringValuesAreByteArray_NoRefreshTtl()
+    public async Task DictionarySetFieldsAsync_FieldsAreStringValuesAreByteArray_NoRefreshTtl()
     {
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
         var content = new Dictionary<string, byte[]>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(100);
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(4900);
 
-        CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Miss, $"Unexpected response: {response}");
+        CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_FieldsAreStringValuesAreByteArray_RefreshTtl()
+    public async Task DictionarySetFieldsAsync_FieldsAreStringValuesAreByteArray_RefreshTtl()
     {
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
         var content = new Dictionary<string, byte[]>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
         await Task.Delay(2000);
 
-        CacheDictionaryGetResponse response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
-        Assert.True(response is CacheDictionaryGetResponse.Hit, $"Unexpected response: {response}");
-        Assert.Equal(value, ((CacheDictionaryGetResponse.Hit)response).ValueByteArray);
+        CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {response}");
+        Assert.Equal(value, ((CacheDictionaryGetFieldResponse.Hit)response).ValueByteArray);
     }
 
     [Fact]
-    public async Task DictionaryGetBatchAsync_NullChecksFieldsAreByteArray_IsError()
+    public async Task DictionaryGetFieldsAsync_NullChecksFieldsAreByteArray_IsError()
     {
         var dictionaryName = Utils.NewGuidString();
         var testData = new byte[][][] { new byte[][] { Utils.NewGuidByteArray(), Utils.NewGuidByteArray() }, new byte[][] { Utils.NewGuidByteArray(), null! } };
 
-        CacheDictionaryGetBatchResponse response = await client.DictionaryGetBatchAsync(null!, dictionaryName, testData[0]);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
-        response = await client.DictionaryGetBatchAsync(cacheName, null!, testData[0]);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
-        response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, (byte[][])null!);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
-        response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, testData[1]);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
+        CacheDictionaryGetFieldsResponse response = await client.DictionaryGetFieldsAsync(null!, dictionaryName, testData[0]);
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetFieldsResponse.Error)response).ErrorCode);
+        response = await client.DictionaryGetFieldsAsync(cacheName, null!, testData[0]);
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetFieldsResponse.Error)response).ErrorCode);
+        response = await client.DictionaryGetFieldsAsync(cacheName, dictionaryName, (byte[][])null!);
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetFieldsResponse.Error)response).ErrorCode);
+        response = await client.DictionaryGetFieldsAsync(cacheName, dictionaryName, testData[1]);
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetFieldsResponse.Error)response).ErrorCode);
 
         var fieldsList = new List<byte[]>(testData[0]);
-        response = await client.DictionaryGetBatchAsync(null!, dictionaryName, fieldsList);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
-        response = await client.DictionaryGetBatchAsync(cacheName, null!, fieldsList);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
-        response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, (List<byte[]>)null!);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
-        response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, new List<byte[]>(testData[1]));
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
+        response = await client.DictionaryGetFieldsAsync(null!, dictionaryName, fieldsList);
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetFieldsResponse.Error)response).ErrorCode);
+        response = await client.DictionaryGetFieldsAsync(cacheName, null!, fieldsList);
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetFieldsResponse.Error)response).ErrorCode);
+        response = await client.DictionaryGetFieldsAsync(cacheName, dictionaryName, (List<byte[]>)null!);
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetFieldsResponse.Error)response).ErrorCode);
+        response = await client.DictionaryGetFieldsAsync(cacheName, dictionaryName, new List<byte[]>(testData[1]));
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetFieldsResponse.Error)response).ErrorCode);
     }
 
     [Fact]
-    public async Task DictionaryGetBatchAsync_FieldsAreByteArrayValuesAreByteArray_HappyPath()
+    public async Task DictionaryGetFieldsAsync_FieldsAreByteArrayValuesAreByteArray_HappyPath()
     {
         var dictionaryName = Utils.NewGuidString();
         var field1 = Utils.NewGuidByteArray();
@@ -661,35 +661,35 @@ public class DictionaryTest : TestBase
         var value2 = Utils.NewGuidByteArray();
         var field3 = Utils.NewGuidByteArray();
 
-        await client.DictionarySetAsync(cacheName, dictionaryName, field1, value1);
-        await client.DictionarySetAsync(cacheName, dictionaryName, field2, value2);
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, field1, value1);
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, field2, value2);
 
-        CacheDictionaryGetBatchResponse response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, new byte[][] { field1, field2, field3 });
-        Assert.True(response is CacheDictionaryGetBatchResponse.Success, $"Unexpected response: {response}");
+        CacheDictionaryGetFieldsResponse response = await client.DictionaryGetFieldsAsync(cacheName, dictionaryName, new byte[][] { field1, field2, field3 });
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Success, $"Unexpected response: {response}");
 
-        var success = (CacheDictionaryGetBatchResponse.Success)response;
+        var success = (CacheDictionaryGetFieldsResponse.Success)response;
         Assert.Equal(3, success.Responses.Count);
-        Assert.True(success.Responses[0] is CacheDictionaryGetResponse.Hit);
-        Assert.True(success.Responses[1] is CacheDictionaryGetResponse.Hit);
-        Assert.True(success.Responses[2] is CacheDictionaryGetResponse.Miss);
+        Assert.True(success.Responses[0] is CacheDictionaryGetFieldResponse.Hit);
+        Assert.True(success.Responses[1] is CacheDictionaryGetFieldResponse.Hit);
+        Assert.True(success.Responses[2] is CacheDictionaryGetFieldResponse.Miss);
         var values = new byte[]?[] { value1, value2, null };
         Assert.Equal(values, success.ValueByteArrays);
     }
 
     [Fact]
-    public async Task DictionaryGetBatchAsync_DictionaryMissing_HappyPath()
+    public async Task DictionaryGetFieldsAsync_DictionaryMissing_HappyPath()
     {
         var dictionaryName = Utils.NewGuidString();
         var field1 = Utils.NewGuidByteArray();
         var field2 = Utils.NewGuidByteArray();
         var field3 = Utils.NewGuidByteArray();
 
-        CacheDictionaryGetBatchResponse response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, new byte[][] { field1, field2, field3 });
-        Assert.True(response is CacheDictionaryGetBatchResponse.Success, $"Unexpected response: {response}");
-        var nullResponse = (CacheDictionaryGetBatchResponse.Success)response;
-        Assert.True(nullResponse.Responses[0] is CacheDictionaryGetResponse.Miss);
-        Assert.True(nullResponse.Responses[1] is CacheDictionaryGetResponse.Miss);
-        Assert.True(nullResponse.Responses[2] is CacheDictionaryGetResponse.Miss);
+        CacheDictionaryGetFieldsResponse response = await client.DictionaryGetFieldsAsync(cacheName, dictionaryName, new byte[][] { field1, field2, field3 });
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Success, $"Unexpected response: {response}");
+        var nullResponse = (CacheDictionaryGetFieldsResponse.Success)response;
+        Assert.True(nullResponse.Responses[0] is CacheDictionaryGetFieldResponse.Miss);
+        Assert.True(nullResponse.Responses[1] is CacheDictionaryGetFieldResponse.Miss);
+        Assert.True(nullResponse.Responses[2] is CacheDictionaryGetFieldResponse.Miss);
         var byteArrays = new byte[]?[] { null, null, null };
         var strings = new string?[] { null, null, null };
 
@@ -698,40 +698,40 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionaryGetBatchAsync_NullChecksFieldsAreString_IsError()
+    public async Task DictionaryGetFieldsAsync_NullChecksFieldsAreString_IsError()
     {
         var dictionaryName = Utils.NewGuidString();
         var testData = new string[][] { new string[] { Utils.NewGuidString(), Utils.NewGuidString() }, new string[] { Utils.NewGuidString(), null! } };
-        CacheDictionaryGetBatchResponse response = await client.DictionaryGetBatchAsync(null!, dictionaryName, testData[0]);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
-        response = await client.DictionaryGetBatchAsync(cacheName, null!, testData[0]);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
-        response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, (string[])null!);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
-        response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, testData[1]);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
+        CacheDictionaryGetFieldsResponse response = await client.DictionaryGetFieldsAsync(null!, dictionaryName, testData[0]);
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetFieldsResponse.Error)response).ErrorCode);
+        response = await client.DictionaryGetFieldsAsync(cacheName, null!, testData[0]);
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetFieldsResponse.Error)response).ErrorCode);
+        response = await client.DictionaryGetFieldsAsync(cacheName, dictionaryName, (string[])null!);
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetFieldsResponse.Error)response).ErrorCode);
+        response = await client.DictionaryGetFieldsAsync(cacheName, dictionaryName, testData[1]);
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetFieldsResponse.Error)response).ErrorCode);
 
         var fieldsList = new List<string>(testData[0]);
-        response = await client.DictionaryGetBatchAsync(null!, dictionaryName, fieldsList);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
-        response = await client.DictionaryGetBatchAsync(cacheName, null!, fieldsList);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
-        response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, (List<string>)null!);
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
-        response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, new List<string>(testData[1]));
-        Assert.True(response is CacheDictionaryGetBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetBatchResponse.Error)response).ErrorCode);
+        response = await client.DictionaryGetFieldsAsync(null!, dictionaryName, fieldsList);
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetFieldsResponse.Error)response).ErrorCode);
+        response = await client.DictionaryGetFieldsAsync(cacheName, null!, fieldsList);
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetFieldsResponse.Error)response).ErrorCode);
+        response = await client.DictionaryGetFieldsAsync(cacheName, dictionaryName, (List<string>)null!);
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetFieldsResponse.Error)response).ErrorCode);
+        response = await client.DictionaryGetFieldsAsync(cacheName, dictionaryName, new List<string>(testData[1]));
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetFieldsResponse.Error)response).ErrorCode);
     }
 
     [Fact]
-    public async Task DictionaryGetBatchAsync_FieldsAreString_HappyPath()
+    public async Task DictionaryGetFieldsAsync_FieldsAreString_HappyPath()
     {
         var dictionaryName = Utils.NewGuidString();
         var field1 = Utils.NewGuidString();
@@ -740,17 +740,17 @@ public class DictionaryTest : TestBase
         var value2 = Utils.NewGuidString();
         var field3 = Utils.NewGuidString();
 
-        await client.DictionarySetAsync(cacheName, dictionaryName, field1, value1);
-        await client.DictionarySetAsync(cacheName, dictionaryName, field2, value2);
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, field1, value1);
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, field2, value2);
 
-        CacheDictionaryGetBatchResponse response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, new string[] { field1, field2, field3 });
-        Assert.True(response is CacheDictionaryGetBatchResponse.Success, $"Unexpected response: {response}");
-        var success = (CacheDictionaryGetBatchResponse.Success)response;
+        CacheDictionaryGetFieldsResponse response = await client.DictionaryGetFieldsAsync(cacheName, dictionaryName, new string[] { field1, field2, field3 });
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Success, $"Unexpected response: {response}");
+        var success = (CacheDictionaryGetFieldsResponse.Success)response;
 
         Assert.Equal(3, success.Responses.Count);
-        Assert.True(success.Responses[0] is CacheDictionaryGetResponse.Hit);
-        Assert.True(success.Responses[1] is CacheDictionaryGetResponse.Hit);
-        Assert.True(success.Responses[2] is CacheDictionaryGetResponse.Miss);
+        Assert.True(success.Responses[0] is CacheDictionaryGetFieldResponse.Hit);
+        Assert.True(success.Responses[1] is CacheDictionaryGetFieldResponse.Hit);
+        Assert.True(success.Responses[2] is CacheDictionaryGetFieldResponse.Miss);
         var values = new string?[] { value1, value2, null };
         Assert.Equal(values, success.ValueStrings);
     }
@@ -786,8 +786,8 @@ public class DictionaryTest : TestBase
             {field2, value2}
         };
 
-        await client.DictionarySetAsync(cacheName, dictionaryName, field1, value1);
-        await client.DictionarySetAsync(cacheName, dictionaryName, field2, value2);
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, field1, value1);
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, field2, value2);
 
         CacheDictionaryFetchResponse fetchResponse = await client.DictionaryFetchAsync(cacheName, dictionaryName);
 
@@ -812,8 +812,8 @@ public class DictionaryTest : TestBase
             {field2, value2}
         };
 
-        await client.DictionarySetAsync(cacheName, dictionaryName, field1, value1);
-        await client.DictionarySetAsync(cacheName, dictionaryName, field2, value2);
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, field1, value1);
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, field2, value2);
 
         CacheDictionaryFetchResponse fetchResponse = await client.DictionaryFetchAsync(cacheName, dictionaryName);
 
@@ -838,8 +838,8 @@ public class DictionaryTest : TestBase
             {field2, value2}
         };
 
-        await client.DictionarySetAsync(cacheName, dictionaryName, field1, value1);
-        await client.DictionarySetAsync(cacheName, dictionaryName, field2, value2);
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, field1, value1);
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, field2, value2);
 
         CacheDictionaryFetchResponse fetchResponse = await client.DictionaryFetchAsync(cacheName, dictionaryName);
 
@@ -881,9 +881,9 @@ public class DictionaryTest : TestBase
     public async Task DictionaryDeleteAsync_DictionaryExists_HappyPath()
     {
         var dictionaryName = Utils.NewGuidString();
-        await client.DictionarySetAsync(cacheName, dictionaryName, Utils.NewGuidString(), Utils.NewGuidString());
-        await client.DictionarySetAsync(cacheName, dictionaryName, Utils.NewGuidString(), Utils.NewGuidString());
-        await client.DictionarySetAsync(cacheName, dictionaryName, Utils.NewGuidString(), Utils.NewGuidString());
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, Utils.NewGuidString(), Utils.NewGuidString());
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, Utils.NewGuidString(), Utils.NewGuidString());
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, Utils.NewGuidString(), Utils.NewGuidString());
 
         Assert.True((await client.DictionaryFetchAsync(cacheName, dictionaryName)) is CacheDictionaryFetchResponse.Hit);
         await client.DictionaryDeleteAsync(cacheName, dictionaryName);
@@ -920,17 +920,17 @@ public class DictionaryTest : TestBase
         var field2 = Utils.NewGuidByteArray();
 
         // Add a field then delete it
-        Assert.True((await client.DictionaryGetAsync(cacheName, dictionaryName, field1)) is CacheDictionaryGetResponse.Miss);
-        await client.DictionarySetAsync(cacheName, dictionaryName, field1, value1);
-        Assert.True((await client.DictionaryGetAsync(cacheName, dictionaryName, field1)) is CacheDictionaryGetResponse.Hit);
+        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1)) is CacheDictionaryGetFieldResponse.Miss);
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, field1, value1);
+        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1)) is CacheDictionaryGetFieldResponse.Hit);
 
         await client.DictionaryRemoveFieldAsync(cacheName, dictionaryName, field1);
-        Assert.True((await client.DictionaryGetAsync(cacheName, dictionaryName, field1)) is CacheDictionaryGetResponse.Miss);
+        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1)) is CacheDictionaryGetFieldResponse.Miss);
 
         // Test no-op
-        Assert.True((await client.DictionaryGetAsync(cacheName, dictionaryName, field2)) is CacheDictionaryGetResponse.Miss);
+        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field2)) is CacheDictionaryGetFieldResponse.Miss);
         await client.DictionaryRemoveFieldAsync(cacheName, dictionaryName, field2);
-        Assert.True((await client.DictionaryGetAsync(cacheName, dictionaryName, field2)) is CacheDictionaryGetResponse.Miss);
+        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field2)) is CacheDictionaryGetFieldResponse.Miss);
     }
 
     [Fact]
@@ -942,17 +942,17 @@ public class DictionaryTest : TestBase
         var field2 = Utils.NewGuidString();
 
         // Add a field then delete it
-        Assert.True((await client.DictionaryGetAsync(cacheName, dictionaryName, field1)) is CacheDictionaryGetResponse.Miss);
-        await client.DictionarySetAsync(cacheName, dictionaryName, field1, value1);
-        Assert.True((await client.DictionaryGetAsync(cacheName, dictionaryName, field1)) is CacheDictionaryGetResponse.Hit);
+        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1)) is CacheDictionaryGetFieldResponse.Miss);
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, field1, value1);
+        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1)) is CacheDictionaryGetFieldResponse.Hit);
 
         await client.DictionaryRemoveFieldAsync(cacheName, dictionaryName, field1);
-        Assert.True((await client.DictionaryGetAsync(cacheName, dictionaryName, field1)) is CacheDictionaryGetResponse.Miss);
+        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1)) is CacheDictionaryGetFieldResponse.Miss);
 
         // Test no-op
-        Assert.True((await client.DictionaryGetAsync(cacheName, dictionaryName, field2)) is CacheDictionaryGetResponse.Miss);
+        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field2)) is CacheDictionaryGetFieldResponse.Miss);
         await client.DictionaryRemoveFieldAsync(cacheName, dictionaryName, field2);
-        Assert.True((await client.DictionaryGetAsync(cacheName, dictionaryName, field2)) is CacheDictionaryGetResponse.Miss);
+        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field2)) is CacheDictionaryGetFieldResponse.Miss);
     }
 
     [Fact]
@@ -997,15 +997,15 @@ public class DictionaryTest : TestBase
         var otherField = Utils.NewGuidByteArray();
 
         // Test enumerable
-        await client.DictionarySetAsync(cacheName, dictionaryName, fields[0], Utils.NewGuidByteArray());
-        await client.DictionarySetAsync(cacheName, dictionaryName, fields[1], Utils.NewGuidByteArray());
-        await client.DictionarySetAsync(cacheName, dictionaryName, otherField, Utils.NewGuidByteArray());
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, fields[0], Utils.NewGuidByteArray());
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, fields[1], Utils.NewGuidByteArray());
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, otherField, Utils.NewGuidByteArray());
 
         var fieldsList = new List<byte[]>(fields);
         await client.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, fieldsList);
-        Assert.True((await client.DictionaryGetAsync(cacheName, dictionaryName, fields[0])) is CacheDictionaryGetResponse.Miss);
-        Assert.True((await client.DictionaryGetAsync(cacheName, dictionaryName, fields[1])) is CacheDictionaryGetResponse.Miss);
-        Assert.True((await client.DictionaryGetAsync(cacheName, dictionaryName, otherField)) is CacheDictionaryGetResponse.Hit);
+        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, fields[0])) is CacheDictionaryGetFieldResponse.Miss);
+        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, fields[1])) is CacheDictionaryGetFieldResponse.Miss);
+        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, otherField)) is CacheDictionaryGetFieldResponse.Hit);
     }
 
     [Fact]
@@ -1049,14 +1049,14 @@ public class DictionaryTest : TestBase
         var otherField = Utils.NewGuidString();
 
         // Test enumerable
-        await client.DictionarySetAsync(cacheName, dictionaryName, fields[0], Utils.NewGuidString());
-        await client.DictionarySetAsync(cacheName, dictionaryName, fields[1], Utils.NewGuidString());
-        await client.DictionarySetAsync(cacheName, dictionaryName, otherField, Utils.NewGuidString());
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, fields[0], Utils.NewGuidString());
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, fields[1], Utils.NewGuidString());
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, otherField, Utils.NewGuidString());
 
         var fieldsList = new List<string>(fields);
         await client.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, fieldsList);
-        Assert.True((await client.DictionaryGetAsync(cacheName, dictionaryName, fields[0])) is CacheDictionaryGetResponse.Miss);
-        Assert.True((await client.DictionaryGetAsync(cacheName, dictionaryName, fields[1])) is CacheDictionaryGetResponse.Miss);
-        Assert.True((await client.DictionaryGetAsync(cacheName, dictionaryName, otherField)) is CacheDictionaryGetResponse.Hit);
+        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, fields[0])) is CacheDictionaryGetFieldResponse.Miss);
+        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, fields[1])) is CacheDictionaryGetFieldResponse.Miss);
+        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, otherField)) is CacheDictionaryGetFieldResponse.Hit);
     }
 }

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/SetTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/SetTest.cs
@@ -16,11 +16,11 @@ public class SetTest : TestBase
     [InlineData(null, "my-set", new byte[] { 0x00 })]
     [InlineData("cache", null, new byte[] { 0x00 })]
     [InlineData("cache", "my-set", null)]
-    public async Task SetAddAsync_NullChecksByteArray_IsError(string cacheName, string setName, byte[] element)
+    public async Task SetAddElementAsync_NullChecksByteArray_IsError(string cacheName, string setName, byte[] element)
     {
-        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element);
-        Assert.True(response is CacheSetAddResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddResponse.Error)response).ErrorCode);
+        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element);
+        Assert.True(response is CacheSetAddElementResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddElementResponse.Error)response).ErrorCode);
     }
 
     [Fact]
@@ -29,8 +29,8 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidByteArray();
 
-        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element);
-        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
+        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element);
+        Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
@@ -46,12 +46,12 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidByteArray();
 
-        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
-        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
+        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(100);
 
-        response = await client.SetAddAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
-        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
+        response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
+        Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(4900);
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
@@ -63,9 +63,9 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidByteArray();
 
-        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
-        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
-        await client.SetAddAsync(cacheName, setName, element, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
+        Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
+        await client.SetAddElementAsync(cacheName, setName, element, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
         await Task.Delay(2000);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
@@ -77,11 +77,11 @@ public class SetTest : TestBase
     [InlineData(null, "my-set", "my-element")]
     [InlineData("cache", null, "my-element")]
     [InlineData("cache", "my-set", null)]
-    public async Task SetAddAsync_NullChecksString_IsError(string cacheName, string setName, string element)
+    public async Task SetAddElementAsync_NullChecksString_IsError(string cacheName, string setName, string element)
     {
-        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element);
-        Assert.True(response is CacheSetAddResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddResponse.Error)response).ErrorCode);
+        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element);
+        Assert.True(response is CacheSetAddElementResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddElementResponse.Error)response).ErrorCode);
     }
 
     [Fact]
@@ -90,8 +90,8 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidString();
 
-        CacheSetAddResponse respose = await client.SetAddAsync(cacheName, setName, element);
-        Assert.True(respose is CacheSetAddResponse.Success, $"Unexpected response: {respose}");
+        CacheSetAddElementResponse respose = await client.SetAddElementAsync(cacheName, setName, element);
+        Assert.True(respose is CacheSetAddElementResponse.Success, $"Unexpected response: {respose}");
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
@@ -107,12 +107,12 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidString();
 
-        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
-        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
+        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(100);
 
-        response = await client.SetAddAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
-        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
+        response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
+        Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(4900);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
@@ -125,10 +125,10 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidString();
 
-        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
-        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
-        response = await client.SetAddAsync(cacheName, setName, element, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
-        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
+        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
+        Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
+        response = await client.SetAddElementAsync(cacheName, setName, element, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(2000);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
@@ -137,36 +137,36 @@ public class SetTest : TestBase
     }
 
     [Fact]
-    public async Task SetAddBatchAsync_NullChecksByteArray_IsError()
+    public async Task SetAddElementsAsync_NullChecksByteArray_IsError()
     {
         var setName = Utils.NewGuidString();
         var set = new HashSet<byte[]>();
-        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(null!, setName, set);
-        Assert.True(response is CacheSetAddBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddBatchResponse.Error)response).ErrorCode);
-        response = await client.SetAddBatchAsync(cacheName, null!, set);
-        Assert.True(response is CacheSetAddBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddBatchResponse.Error)response).ErrorCode);
-        response = await client.SetAddBatchAsync(cacheName, setName, (IEnumerable<byte[]>)null!);
-        Assert.True(response is CacheSetAddBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddBatchResponse.Error)response).ErrorCode);
+        CacheSetAddElementsResponse response = await client.SetAddElementsAsync(null!, setName, set);
+        Assert.True(response is CacheSetAddElementsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddElementsResponse.Error)response).ErrorCode);
+        response = await client.SetAddElementsAsync(cacheName, null!, set);
+        Assert.True(response is CacheSetAddElementsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddElementsResponse.Error)response).ErrorCode);
+        response = await client.SetAddElementsAsync(cacheName, setName, (IEnumerable<byte[]>)null!);
+        Assert.True(response is CacheSetAddElementsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddElementsResponse.Error)response).ErrorCode);
 
         set.Add(null!);
-        response = await client.SetAddBatchAsync(cacheName, setName, set);
-        Assert.True(response is CacheSetAddBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddBatchResponse.Error)response).ErrorCode);
+        response = await client.SetAddElementsAsync(cacheName, setName, set);
+        Assert.True(response is CacheSetAddElementsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddElementsResponse.Error)response).ErrorCode);
     }
 
     [Fact]
-    public async Task SetAddBatchAsync_ElementsAreByteArrayEnumerable_HappyPath()
+    public async Task SetAddElementsAsync_ElementsAreByteArrayEnumerable_HappyPath()
     {
         var setName = Utils.NewGuidString();
         var element1 = Utils.NewGuidByteArray();
         var element2 = Utils.NewGuidByteArray();
         var content = new List<byte[]>() { element1, element2 };
 
-        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content);
-        Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
+        CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content);
+        Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
@@ -178,18 +178,18 @@ public class SetTest : TestBase
     }
 
     [Fact]
-    public async Task SetAddBatchAsync_ElementsAreByteArrayEnumerable_noRefreshTtlOnUpdates()
+    public async Task SetAddElementsAsync_ElementsAreByteArrayEnumerable_noRefreshTtlOnUpdates()
     {
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidByteArray();
         var content = new List<byte[]>() { element };
 
-        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
-        Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
+        CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(100);
 
-        response = await client.SetAddBatchAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
-        Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
+        response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
+        Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(4900);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
@@ -197,15 +197,15 @@ public class SetTest : TestBase
     }
 
     [Fact]
-    public async Task SetAddBatchAsync_ElementsAreByteArrayEnumerable_RefreshTtl()
+    public async Task SetAddElementsAsync_ElementsAreByteArrayEnumerable_RefreshTtl()
     {
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidByteArray();
         var content = new List<byte[]>() { element };
 
-        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
-        Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
-        await client.SetAddBatchAsync(cacheName, setName, content, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
+        Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
+        await client.SetAddElementsAsync(cacheName, setName, content, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
         await Task.Delay(2000);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
@@ -217,36 +217,36 @@ public class SetTest : TestBase
     }
 
     [Fact]
-    public async Task SetAddBatchAsync_NullChecksString_IsError()
+    public async Task SetAddElementsAsync_NullChecksString_IsError()
     {
         var setName = Utils.NewGuidString();
         var set = new HashSet<string>();
-        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(null!, setName, set);
-        Assert.True(response is CacheSetAddBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddBatchResponse.Error)response).ErrorCode);
-        response = await client.SetAddBatchAsync(cacheName, null!, set);
-        Assert.True(response is CacheSetAddBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddBatchResponse.Error)response).ErrorCode);
-        response = await client.SetAddBatchAsync(cacheName, setName, (IEnumerable<string>)null!);
-        Assert.True(response is CacheSetAddBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddBatchResponse.Error)response).ErrorCode);
+        CacheSetAddElementsResponse response = await client.SetAddElementsAsync(null!, setName, set);
+        Assert.True(response is CacheSetAddElementsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddElementsResponse.Error)response).ErrorCode);
+        response = await client.SetAddElementsAsync(cacheName, null!, set);
+        Assert.True(response is CacheSetAddElementsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddElementsResponse.Error)response).ErrorCode);
+        response = await client.SetAddElementsAsync(cacheName, setName, (IEnumerable<string>)null!);
+        Assert.True(response is CacheSetAddElementsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddElementsResponse.Error)response).ErrorCode);
 
         set.Add(null!);
-        response = await client.SetAddBatchAsync(cacheName, setName, set);
-        Assert.True(response is CacheSetAddBatchResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddBatchResponse.Error)response).ErrorCode);
+        response = await client.SetAddElementsAsync(cacheName, setName, set);
+        Assert.True(response is CacheSetAddElementsResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetAddElementsResponse.Error)response).ErrorCode);
     }
 
     [Fact]
-    public async Task SetAddBatchAsync_ElementsAreStringEnumerable_HappyPath()
+    public async Task SetAddElementsAsync_ElementsAreStringEnumerable_HappyPath()
     {
         var setName = Utils.NewGuidString();
         var element1 = Utils.NewGuidString();
         var element2 = Utils.NewGuidString();
         var content = new List<string>() { element1, element2 };
 
-        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content);
-        Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
+        CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content);
+        Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
@@ -258,18 +258,18 @@ public class SetTest : TestBase
     }
 
     [Fact]
-    public async Task SetAddBatchAsync_ElementsAreStringEnumerable_noRefreshTtlOnUpdates()
+    public async Task SetAddElementsAsync_ElementsAreStringEnumerable_noRefreshTtlOnUpdates()
     {
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidString();
         var content = new List<string>() { element };
 
-        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
-        Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
+        CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(100);
 
-        response = await client.SetAddBatchAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
-        Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
+        response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
+        Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(4900);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
@@ -277,16 +277,16 @@ public class SetTest : TestBase
     }
 
     [Fact]
-    public async Task SetAddBatchAsync_ElementsAreStringEnumerable_RefreshTtl()
+    public async Task SetAddElementsAsync_ElementsAreStringEnumerable_RefreshTtl()
     {
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidString();
         var content = new List<string>() { element };
 
-        CacheSetAddBatchResponse response = await client.SetAddBatchAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
-        Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
-        response = await client.SetAddBatchAsync(cacheName, setName, content, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
-        Assert.True(response is CacheSetAddBatchResponse.Success, $"Unexpected response: {response}");
+        CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
+        Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
+        response = await client.SetAddElementsAsync(cacheName, setName, content, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(2000);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
@@ -314,8 +314,8 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidByteArray();
 
-        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element);
-        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
+        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element);
+        Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
 
         // Remove element that is not there -- no-op
         CacheSetRemoveElementResponse removeResponse = await client.SetRemoveElementAsync(cacheName, setName, Utils.NewGuidByteArray());
@@ -368,8 +368,8 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidString();
 
-        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, element);
-        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
+        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element);
+        Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
 
         // Remove element that is not there -- no-op
         CacheSetRemoveElementResponse removeResponse = await client.SetRemoveElementAsync(cacheName, setName, Utils.NewGuidString());
@@ -446,12 +446,12 @@ public class SetTest : TestBase
         var otherElement = Utils.NewGuidByteArray();
 
         // Test enumerable
-        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, elements[0]);
-        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
-        await client.SetAddAsync(cacheName, setName, elements[1]);
-        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
-        await client.SetAddAsync(cacheName, setName, otherElement);
-        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
+        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, elements[0]);
+        Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
+        await client.SetAddElementAsync(cacheName, setName, elements[1]);
+        Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
+        await client.SetAddElementAsync(cacheName, setName, otherElement);
+        Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
 
         var elementsList = new List<byte[]>(elements);
         CacheSetRemoveElementsResponse removeResponse = await client.SetRemoveElementsAsync(cacheName, setName, elementsList);
@@ -505,12 +505,12 @@ public class SetTest : TestBase
         var otherElement = Utils.NewGuidByteArray();
 
         // Test enumerable
-        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, elements[0]);
-        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
-        response = await client.SetAddAsync(cacheName, setName, elements[1]);
-        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
-        response = await client.SetAddAsync(cacheName, setName, otherElement);
-        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
+        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, elements[0]);
+        Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
+        response = await client.SetAddElementAsync(cacheName, setName, elements[1]);
+        Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
+        response = await client.SetAddElementAsync(cacheName, setName, otherElement);
+        Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
 
         var elementsList = new List<string>(elements);
         CacheSetRemoveElementsResponse removeResponse = await client.SetRemoveElementsAsync(cacheName, setName, elementsList);
@@ -544,8 +544,8 @@ public class SetTest : TestBase
     public async Task SetFetchAsync_UsesCachedByteArraySet_HappyPath()
     {
         var setName = Utils.NewGuidString();
-        CacheSetAddBatchResponse setResponse = await client.SetAddBatchAsync(cacheName, setName, new string[] { Utils.NewGuidString(), Utils.NewGuidString() });
-        Assert.True(setResponse is CacheSetAddBatchResponse.Success, $"Unexpected response: {setResponse}");
+        CacheSetAddElementsResponse setResponse = await client.SetAddElementsAsync(cacheName, setName, new string[] { Utils.NewGuidString(), Utils.NewGuidString() });
+        Assert.True(setResponse is CacheSetAddElementsResponse.Success, $"Unexpected response: {setResponse}");
         CacheSetFetchResponse response = await client.SetFetchAsync(cacheName, setName);
         Assert.True(response is CacheSetFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheSetFetchResponse.Hit)response;
@@ -558,8 +558,8 @@ public class SetTest : TestBase
     public async Task SetFetchAsync_UsesCachedStringSet_HappyPath()
     {
         var setName = Utils.NewGuidString();
-        CacheSetAddBatchResponse setResponse = await client.SetAddBatchAsync(cacheName, setName, new string[] { Utils.NewGuidString(), Utils.NewGuidString() });
-        Assert.True(setResponse is CacheSetAddBatchResponse.Success, $"Unexpected response: {setResponse}");
+        CacheSetAddElementsResponse setResponse = await client.SetAddElementsAsync(cacheName, setName, new string[] { Utils.NewGuidString(), Utils.NewGuidString() });
+        Assert.True(setResponse is CacheSetAddElementsResponse.Success, $"Unexpected response: {setResponse}");
         CacheSetFetchResponse response = await client.SetFetchAsync(cacheName, setName);
         Assert.True(response is CacheSetFetchResponse.Hit, $"Unexpected response: {response}");
         var hitResponse = (CacheSetFetchResponse.Hit)response;
@@ -592,12 +592,12 @@ public class SetTest : TestBase
     public async Task SetDeleteAsync_SetExists_HappyPath()
     {
         var setName = Utils.NewGuidString();
-        CacheSetAddResponse response = await client.SetAddAsync(cacheName, setName, Utils.NewGuidString());
-        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
-        response = await client.SetAddAsync(cacheName, setName, Utils.NewGuidString());
-        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
-        response = await client.SetAddAsync(cacheName, setName, Utils.NewGuidString());
-        Assert.True(response is CacheSetAddResponse.Success, $"Unexpected response: {response}");
+        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, Utils.NewGuidString());
+        Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
+        response = await client.SetAddElementAsync(cacheName, setName, Utils.NewGuidString());
+        Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
+        response = await client.SetAddElementAsync(cacheName, setName, Utils.NewGuidString());
+        Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
 
         Assert.True(await client.SetFetchAsync(cacheName, setName) is CacheSetFetchResponse.Hit);
         CacheSetDeleteResponse deleteResponse = await client.SetDeleteAsync(cacheName, setName);


### PR DESCRIPTION
I opened this pr instead of restoring file/class names in [this](https://github.com/momentohq/client-sdk-dotnet-incubating/pull/60) previous pr.

- Renamed dictionary and set operations names except `DictionaryRemoveField`, `DictionaryRemoveFields`,`SetRemoveElement`, and `SetRemoveElements` since they were already named that way.

Closes #39 