### PR TITLE
refactor: use hit/miss/error pattern for dictremovefields response

### DIFF
--- a/src/Momento.Sdk.Incubating/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk.Incubating/Internal/ScsDataClient.cs
@@ -314,9 +314,9 @@ internal sealed class ScsDataClient : ScsDataClientBase
         }
         if (response.DictionaryCase == _DictionaryGetResponse.DictionaryOneofCase.Found)
         {
-            return new CacheDictionaryGetFieldsResponse.Success(response);
+            return new CacheDictionaryGetFieldsResponse.Hit(response);
         }
-        return new CacheDictionaryGetFieldsResponse.Success(fields.Count());
+        return new CacheDictionaryGetFieldsResponse.Miss();
     }
 
     public async Task<CacheDictionaryFetchResponse> DictionaryFetchAsync(string cacheName, string dictionaryName)

--- a/src/Momento.Sdk.Incubating/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk.Incubating/Internal/ScsDataClient.cs
@@ -314,7 +314,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         }
         if (response.DictionaryCase == _DictionaryGetResponse.DictionaryOneofCase.Found)
         {
-            return new CacheDictionaryGetFieldsResponse.Hit(response);
+            return new CacheDictionaryGetFieldsResponse.Hit(fields, response);
         }
         return new CacheDictionaryGetFieldsResponse.Miss();
     }

--- a/src/Momento.Sdk.Incubating/Responses/CacheDictionaryFetchResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheDictionaryFetchResponse.cs
@@ -14,37 +14,37 @@ public abstract class CacheDictionaryFetchResponse
     public class Hit : CacheDictionaryFetchResponse
     {
         protected readonly RepeatedField<_DictionaryFieldValuePair>? items;
-        protected readonly Lazy<Dictionary<byte[], byte[]>> _byteArrayByteArrayDictionary;
-        protected readonly Lazy<Dictionary<string, string>> _stringStringDictionary;
-        protected readonly Lazy<Dictionary<string, byte[]>> _stringByteArrayDictionary;
+        protected readonly Lazy<Dictionary<byte[], byte[]>> _dictionaryByteArrayByteArray;
+        protected readonly Lazy<Dictionary<string, string>> _dictionaryStringString;
+        protected readonly Lazy<Dictionary<string, byte[]>> _dictionaryStringByteArray;
 
         public Hit(_DictionaryFetchResponse response)
         {
             items = response.Found.Items;
-            _byteArrayByteArrayDictionary = new(() =>
+            _dictionaryByteArrayByteArray = new(() =>
             {
                 return new Dictionary<byte[], byte[]>(
                     items.Select(kv => new KeyValuePair<byte[], byte[]>(kv.Field.ToByteArray(), kv.Value.ToByteArray())),
                     Utils.ByteArrayComparer);
             });
 
-            _stringStringDictionary = new(() =>
+            _dictionaryStringString = new(() =>
             {
                 return new Dictionary<string, string>(
                     items.Select(kv => new KeyValuePair<string, string>(kv.Field.ToStringUtf8(), kv.Value.ToStringUtf8())));
             });
-            _stringByteArrayDictionary = new(() =>
+            _dictionaryStringByteArray = new(() =>
             {
                 return new Dictionary<string, byte[]>(
                     items.Select(kv => new KeyValuePair<string, byte[]>(kv.Field.ToStringUtf8(), kv.Value.ToByteArray())));
             });
         }
 
-        public Dictionary<byte[], byte[]> ValueDictionaryByteArrayByteArray { get => _byteArrayByteArrayDictionary.Value; }
+        public Dictionary<byte[], byte[]> ValueDictionaryByteArrayByteArray { get => _dictionaryByteArrayByteArray.Value; }
 
-        public Dictionary<string, string> ValueDictionaryStringString { get => _stringStringDictionary.Value; }
+        public Dictionary<string, string> ValueDictionaryStringString { get => _dictionaryStringString.Value; }
 
-        public Dictionary<string, byte[]> ValueDictionaryStringByteArray { get => _stringByteArrayDictionary.Value; }
+        public Dictionary<string, byte[]> ValueDictionaryStringByteArray { get => _dictionaryStringByteArray.Value; }
     }
 
     public class Miss : CacheDictionaryFetchResponse

--- a/src/Momento.Sdk.Incubating/Responses/CacheDictionaryGetFieldsResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheDictionaryGetFieldsResponse.cs
@@ -11,11 +11,11 @@ namespace Momento.Sdk.Incubating.Responses;
 
 public abstract class CacheDictionaryGetFieldsResponse
 {
-    public class Success : CacheDictionaryGetFieldsResponse
+    public class Hit : CacheDictionaryGetFieldsResponse
     {
         public List<CacheDictionaryGetFieldResponse> Responses { get; private set; }
 
-        public Success(_DictionaryGetResponse responses)
+        public Hit(_DictionaryGetResponse responses)
         {
             var responsesList = new List<CacheDictionaryGetFieldResponse>();
             foreach (_DictionaryGetResponsePart response in responses.Found.Items)
@@ -35,51 +35,11 @@ public abstract class CacheDictionaryGetFieldsResponse
             }
             this.Responses = responsesList;
         }
+    }
 
-        public Success(int numRequested)
-        {
-            Responses = Enumerable.Range(1, numRequested).Select(_ => new CacheDictionaryGetFieldResponse.Miss()).ToList<CacheDictionaryGetFieldResponse>();
-        }
+    public class Miss : CacheDictionaryGetFieldsResponse
+    {
 
-        public IEnumerable<string?> ValueStrings
-        {
-            get
-            {
-                var ret = new List<string?>();
-                foreach (CacheDictionaryGetFieldResponse response in Responses)
-                {
-                    if (response is CacheDictionaryGetFieldResponse.Hit hitResponse)
-                    {
-                        ret.Add(hitResponse.ValueString);
-                    }
-                    else if (response is CacheDictionaryGetFieldResponse.Miss missResponse)
-                    {
-                        ret.Add(null);
-                    }
-                }
-                return ret.ToArray();
-            }
-        }
-
-        public IEnumerable<byte[]?> ValueByteArrays
-        {
-            get
-            {
-                var ret = new List<byte[]?>();
-                foreach (CacheDictionaryGetFieldResponse response in Responses)
-                {
-                    if (response is CacheDictionaryGetFieldResponse.Hit hitResponse)
-                    {
-                        ret.Add(hitResponse.ValueByteArray);
-                    }
-                    else if (response is CacheDictionaryGetFieldResponse.Miss missResponse)
-                    {
-                        ret.Add(null);
-                    }
-                }
-                return ret.ToArray();
-            }
-        }
     }
 
     public class Error : CacheDictionaryGetFieldsResponse

--- a/src/Momento.Sdk.Incubating/Responses/CacheDictionaryGetFieldsResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheDictionaryGetFieldsResponse.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Google.Protobuf;
 using Google.Protobuf.Collections;
 using Momento.Protos.CacheClient;
 using Momento.Sdk.Exceptions;
-using Momento.Sdk.Responses;
+using Momento.Sdk.Internal;
 using static Momento.Protos.CacheClient._DictionaryGetResponse.Types;
 
 namespace Momento.Sdk.Incubating.Responses;
@@ -14,8 +15,11 @@ public abstract class CacheDictionaryGetFieldsResponse
     public class Hit : CacheDictionaryGetFieldsResponse
     {
         public List<CacheDictionaryGetFieldResponse> Responses { get; private set; }
+        protected readonly Lazy<Dictionary<byte[], byte[]>> _dictionaryByteArrayByteArray;
+        protected readonly Lazy<Dictionary<string, string>> _dictionaryStringString;
+        protected readonly Lazy<Dictionary<string, byte[]>> _dictionaryStringByteArray;
 
-        public Hit(_DictionaryGetResponse responses)
+        public Hit(IEnumerable<ByteString> fields, _DictionaryGetResponse responses)
         {
             var responsesList = new List<CacheDictionaryGetFieldResponse>();
             foreach (_DictionaryGetResponsePart response in responses.Found.Items)
@@ -34,7 +38,37 @@ public abstract class CacheDictionaryGetFieldsResponse
                 }
             }
             this.Responses = responsesList;
+
+            _dictionaryByteArrayByteArray = new(() =>
+            {
+                return new Dictionary<byte[], byte[]>(
+                    fields.Zip(responses.Found.Items, (f, r) => new ValueTuple<ByteString, _DictionaryGetResponsePart>(f, r))
+                        .Where(pair => pair.Item2.Result == ECacheResult.Hit)
+                        .Select(pair => new KeyValuePair<byte[], byte[]>(pair.Item1.ToByteArray(), pair.Item2.CacheBody.ToByteArray())),
+                    Utils.ByteArrayComparer);
+            });
+
+            _dictionaryStringString = new(() =>
+            {
+                return new Dictionary<string, string>(
+                    fields.Zip(responses.Found.Items, (f, r) => new ValueTuple<ByteString, _DictionaryGetResponsePart>(f, r))
+                        .Where(pair => pair.Item2.Result == ECacheResult.Hit)
+                        .Select(pair => new KeyValuePair<string, string>(pair.Item1.ToStringUtf8(), pair.Item2.CacheBody.ToStringUtf8())));
+            });
+            _dictionaryStringByteArray = new(() =>
+            {
+                return new Dictionary<string, byte[]>(
+                    fields.Zip(responses.Found.Items, (f, r) => new ValueTuple<ByteString, _DictionaryGetResponsePart>(f, r))
+                        .Where(pair => pair.Item2.Result == ECacheResult.Hit)
+                        .Select(pair => new KeyValuePair<string, byte[]>(pair.Item1.ToStringUtf8(), pair.Item2.CacheBody.ToByteArray())));
+            });
         }
+
+        public Dictionary<byte[], byte[]> ValueDictionaryByteArrayByteArray { get => _dictionaryByteArrayByteArray.Value; }
+
+        public Dictionary<string, string> ValueDictionaryStringString { get => _dictionaryStringString.Value; }
+
+        public Dictionary<string, byte[]> ValueDictionaryStringByteArray { get => _dictionaryStringByteArray.Value; }
     }
 
     public class Miss : CacheDictionaryGetFieldsResponse

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
@@ -674,6 +674,9 @@ public class DictionaryTest : TestBase
         Assert.True(hit.Responses[1] is CacheDictionaryGetFieldResponse.Hit, $"should be hit but was {hit.Responses[1]}");
         Assert.Equal(value2, ((CacheDictionaryGetFieldResponse.Hit)hit.Responses[1]).ValueByteArray);
         Assert.True(hit.Responses[2] is CacheDictionaryGetFieldResponse.Miss, $"should be miss but was {hit.Responses[2]}");
+
+        var expectedDictionary = new Dictionary<byte[], byte[]>() { { field1, value1 }, { field2, value2 } };
+        Assert.True(hit.ValueDictionaryByteArrayByteArray.DictionaryEquals(expectedDictionary), "dictionaries did not match");
     }
 
     [Fact]
@@ -744,6 +747,14 @@ public class DictionaryTest : TestBase
         Assert.True(hit.Responses[1] is CacheDictionaryGetFieldResponse.Hit, $"should be hit but was {hit.Responses[1]}");
         Assert.Equal(value2, ((CacheDictionaryGetFieldResponse.Hit)hit.Responses[1]).ValueString);
         Assert.True(hit.Responses[2] is CacheDictionaryGetFieldResponse.Miss, $"should be miss but was {hit.Responses[2]}");
+
+        var expectedDictionary = new Dictionary<string, string> { { field1, value1 }, { field2, value2 } };
+        Assert.Equal(expectedDictionary, hit.ValueDictionaryStringString);
+
+        var otherDictionary = hit.ValueDictionaryStringByteArray;
+        Assert.Equal(2, otherDictionary.Count);
+        Assert.Equal(otherDictionary[field1], Utils.Utf8ToByteArray(value1));
+        Assert.Equal(otherDictionary[field2], Utils.Utf8ToByteArray(value2));
     }
 
     [Theory]

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
@@ -665,15 +665,15 @@ public class DictionaryTest : TestBase
         await client.DictionarySetFieldAsync(cacheName, dictionaryName, field2, value2);
 
         CacheDictionaryGetFieldsResponse response = await client.DictionaryGetFieldsAsync(cacheName, dictionaryName, new byte[][] { field1, field2, field3 });
-        Assert.True(response is CacheDictionaryGetFieldsResponse.Success, $"Unexpected response: {response}");
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Hit, $"Unexpected response: {response}");
 
-        var success = (CacheDictionaryGetFieldsResponse.Success)response;
-        Assert.Equal(3, success.Responses.Count);
-        Assert.True(success.Responses[0] is CacheDictionaryGetFieldResponse.Hit);
-        Assert.True(success.Responses[1] is CacheDictionaryGetFieldResponse.Hit);
-        Assert.True(success.Responses[2] is CacheDictionaryGetFieldResponse.Miss);
-        var values = new byte[]?[] { value1, value2, null };
-        Assert.Equal(values, success.ValueByteArrays);
+        var hit = (CacheDictionaryGetFieldsResponse.Hit)response;
+        Assert.Equal(3, hit.Responses.Count);
+        Assert.True(hit.Responses[0] is CacheDictionaryGetFieldResponse.Hit, $"should be hit but was {hit.Responses[0]}");
+        Assert.Equal(value1, ((CacheDictionaryGetFieldResponse.Hit)hit.Responses[0]).ValueByteArray);
+        Assert.True(hit.Responses[1] is CacheDictionaryGetFieldResponse.Hit, $"should be hit but was {hit.Responses[1]}");
+        Assert.Equal(value2, ((CacheDictionaryGetFieldResponse.Hit)hit.Responses[1]).ValueByteArray);
+        Assert.True(hit.Responses[2] is CacheDictionaryGetFieldResponse.Miss, $"should be miss but was {hit.Responses[2]}");
     }
 
     [Fact]
@@ -685,16 +685,7 @@ public class DictionaryTest : TestBase
         var field3 = Utils.NewGuidByteArray();
 
         CacheDictionaryGetFieldsResponse response = await client.DictionaryGetFieldsAsync(cacheName, dictionaryName, new byte[][] { field1, field2, field3 });
-        Assert.True(response is CacheDictionaryGetFieldsResponse.Success, $"Unexpected response: {response}");
-        var nullResponse = (CacheDictionaryGetFieldsResponse.Success)response;
-        Assert.True(nullResponse.Responses[0] is CacheDictionaryGetFieldResponse.Miss);
-        Assert.True(nullResponse.Responses[1] is CacheDictionaryGetFieldResponse.Miss);
-        Assert.True(nullResponse.Responses[2] is CacheDictionaryGetFieldResponse.Miss);
-        var byteArrays = new byte[]?[] { null, null, null };
-        var strings = new string?[] { null, null, null };
-
-        Assert.Equal(byteArrays, nullResponse.ValueByteArrays);
-        Assert.Equal(strings, nullResponse.ValueStrings!);
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -744,15 +735,15 @@ public class DictionaryTest : TestBase
         await client.DictionarySetFieldAsync(cacheName, dictionaryName, field2, value2);
 
         CacheDictionaryGetFieldsResponse response = await client.DictionaryGetFieldsAsync(cacheName, dictionaryName, new string[] { field1, field2, field3 });
-        Assert.True(response is CacheDictionaryGetFieldsResponse.Success, $"Unexpected response: {response}");
-        var success = (CacheDictionaryGetFieldsResponse.Success)response;
+        Assert.True(response is CacheDictionaryGetFieldsResponse.Hit, $"Unexpected response: {response}");
 
-        Assert.Equal(3, success.Responses.Count);
-        Assert.True(success.Responses[0] is CacheDictionaryGetFieldResponse.Hit);
-        Assert.True(success.Responses[1] is CacheDictionaryGetFieldResponse.Hit);
-        Assert.True(success.Responses[2] is CacheDictionaryGetFieldResponse.Miss);
-        var values = new string?[] { value1, value2, null };
-        Assert.Equal(values, success.ValueStrings);
+        var hit = (CacheDictionaryGetFieldsResponse.Hit)response;
+        Assert.Equal(3, hit.Responses.Count);
+        Assert.True(hit.Responses[0] is CacheDictionaryGetFieldResponse.Hit, $"should be hit but was {hit.Responses[0]}");
+        Assert.Equal(value1, ((CacheDictionaryGetFieldResponse.Hit)hit.Responses[0]).ValueString);
+        Assert.True(hit.Responses[1] is CacheDictionaryGetFieldResponse.Hit, $"should be hit but was {hit.Responses[1]}");
+        Assert.Equal(value2, ((CacheDictionaryGetFieldResponse.Hit)hit.Responses[1]).ValueString);
+        Assert.True(hit.Responses[2] is CacheDictionaryGetFieldResponse.Miss, $"should be miss but was {hit.Responses[2]}");
     }
 
     [Theory]


### PR DESCRIPTION
We refactor `CacheDictionaryGetFieldsResponse` to use the Hit/Miss/Error pattern. In doing so we remove the need for the previous payload accessors. When a dictionary is not found, we return `CacheDictionaryGetFieldsResponse.Miss` instead of `Success` with unary response objects that are all `Miss`.

We also add a payload accessor convenience similar to the one in `CacheDictionaryFetchResponse`. The end-user can retrieve the payload as a dictionary. Note in particular: when a queried field is missing from the cache, we do not include it in the dictionary. An alternative would be to include the field in the dictionary and associate to it a `null` value, which is allowed in .NET. Since we cannot store `null` values in the cache, we instead adopt the convention $\text{field cache miss} \implies \text{not present}$.

closes #47 
closes #40 
