### PR TITLE
feat: extract incubating methods to incubating client interface

### DIFF
--- a/src/Momento.Sdk.Incubating/ISimpleCacheClient.cs
+++ b/src/Momento.Sdk.Incubating/ISimpleCacheClient.cs
@@ -1,0 +1,365 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Momento.Sdk.Exceptions;
+using Momento.Sdk.Incubating.Requests;
+using Momento.Sdk.Incubating.Responses;
+
+namespace Momento.Sdk.Incubating;
+
+/// <summary>
+/// Minimum viable functionality of a cache client.
+///
+/// Includes control operations and data operations.
+/// </summary>
+public interface ISimpleCacheClient : Momento.Sdk.ISimpleCacheClient
+{
+#if USE_UNARY_BATCH
+    /// <summary>
+    /// Gets multiple values from the cache.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="keys">The keys to get.</param>
+    /// <returns>Task object representing the statuses of the get operation and the associated values.</returns>
+    public Task<CacheGetBatchResponse> GetBatchAsync(string cacheName, IEnumerable<byte[]> keys);
+
+    /// <inheritdoc cref="GetBatchAsync(string, IEnumerable{byte[]})"/>
+    public Task<CacheGetBatchResponse> GetBatchAsync(string cacheName, IEnumerable<string> keys);
+
+    /// <summary>
+    /// Sets multiple items in the cache. Overwrites existing items.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to store the items in.</param>
+    /// <param name="items">The items to set.</param>
+    /// <param name="ttl">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <returns>Task object representing the result of the set operation.</returns>
+    public Task<CacheSetBatchResponse> SetBatchAsync(string cacheName, IEnumerable<KeyValuePair<byte[], byte[]>> items, TimeSpan? ttl = null);
+
+    /// <inheritdoc cref="SetBatchAsync(string, IEnumerable{KeyValuePair{byte[], byte[]}}, TimeSpan?)"/>
+    public Task<CacheSetBatchResponse> SetBatchAsync(string cacheName, IEnumerable<KeyValuePair<string, string>> items, TimeSpan? ttl = null);
+#endif
+
+    /// <summary>
+    /// Set the dictionary field to a value with a given time to live (TTL) seconds.
+    /// </summary>
+    /// <remark>
+    /// Creates the data structure if it does not exist
+    /// </remark>
+    /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
+    /// <param name="dictionaryName">The dictionary to set.</param>
+    /// <param name="field">The field in the dictionary to set.</param>
+    /// <param name="value">The value to be stored.</param>
+    /// <param name="ttl">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <returns>Task representing the result of the cache operation.</returns>
+    public Task<CacheDictionarySetFieldResponse> DictionarySetFieldAsync(string cacheName, string dictionaryName, byte[] field, byte[] value, CollectionTtl ttl = default(CollectionTtl));
+
+    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)"/>
+    public Task<CacheDictionarySetFieldResponse> DictionarySetFieldAsync(string cacheName, string dictionaryName, string field, string value, CollectionTtl ttl = default(CollectionTtl));
+
+    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)"/>
+    public Task<CacheDictionarySetFieldResponse> DictionarySetFieldAsync(string cacheName, string dictionaryName, string field, byte[] value, CollectionTtl ttl = default(CollectionTtl));
+
+    /// <summary>
+    /// Get the cache value stored for the given dictionary and field.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="dictionaryName">The dictionary to lookup.</param>
+    /// <param name="field">The field in the dictionary to lookup.</param>
+    /// <returns>Task representing the status of the get operation and the associated value.</returns>
+    public Task<CacheDictionaryGetFieldResponse> DictionaryGetFieldAsync(string cacheName, string dictionaryName, byte[] field);
+
+    /// <inheritdoc cref="DictionaryGetFieldAsync(string, string, byte[])"/>
+    public Task<CacheDictionaryGetFieldResponse> DictionaryGetFieldAsync(string cacheName, string dictionaryName, string field);
+
+    /// <summary>
+    /// Set several dictionary field-value pairs in the cache.
+    /// </summary>
+    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
+    /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
+    /// <param name="dictionaryName">The dictionary to set.</param>
+    /// <param name="items">The field-value pairs in the dictionary to set.</param>
+    /// <param name="ttl">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <returns>Task representing the result of the cache operation.</returns>
+    public Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> items, CollectionTtl ttl = default(CollectionTtl));
+
+    /// <inheritdoc cref="DictionarySetFieldsAsync(string, string, IEnumerable{KeyValuePair{byte[], byte[]}}, CollectionTtl)"/>
+    public Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, string>> items, CollectionTtl ttl = default(CollectionTtl));
+
+    /// <inheritdoc cref="DictionarySetFieldsAsync(string, string, IEnumerable{KeyValuePair{byte[], byte[]}}, CollectionTtl)"/>
+    public Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> items, CollectionTtl ttl = default(CollectionTtl));
+
+    /// <summary>
+    /// <para>Add an integer quantity to a dictionary value.</para>
+    ///
+    /// <para>Incrementing the value of a missing field sets the value to <paramref name="amount"/>.</para>
+    /// <para>Incrementing a value that was not set using this method or not the string representation of an integer
+    /// results in an error with <see cref="FailedPreconditionException"/>.</para>
+    /// </summary>
+    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
+    /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
+    /// <param name="dictionaryName">The dictionary to set.</param>
+    /// <param name="field"></param>
+    /// <param name="amount">The quantity to add to the value. May be positive, negative, or zero. Defaults to 1.</param>
+    /// <param name="ttl">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <returns>Task representing the result of the cache operation.</returns>
+    /// <example>
+    /// The following illustrates a typical workflow:
+    /// <code>
+    ///     var response = await client.DictionaryIncrementAsync(cacheName, "my dictionary", "counter", amount: 42);
+    ///     if (response is CacheDictionaryIncrementResponse.Success success)
+    ///     {
+    ///         Console.WriteLine($"Current value is {success.Value}");
+    ///     }
+    ///     else if (response is CacheDictionaryIncrementResponse.Error error)
+    ///     {
+    ///         Console.WriteLine($"Got an error: {error.Message}");
+    ///     }
+    ///
+    ///     // Reset the counter. Note we use the string representation of an integer.
+    ///     var setResponse = await client.DictionarySetFieldAsync(cacheName, "my dictionary", "counter", "0");
+    ///     if (setResponse is CacheDictionarySetFieldResponse.Error) { /* handle error */ }
+    ///
+    ///     // Retrieve the counter. The integer is represented as a string.
+    ///     var getResponse = await client.DictionaryGetFieldAsync(cacheName, "my dictionary", "counter");
+    ///     if (getResponse is CacheDictionaryGetFieldResponse.Hit getHit)
+    ///     {
+    ///         Console.WriteLine(getHit.String());
+    ///     }
+    ///     else if (getResponse is CacheDictionaryGetFieldResponse.Error) { /* handle error */ }
+    ///
+    ///     // Here we try incrementing a value that isn't an integer. This results in an error with <see cref="FailedPreconditionException"/>
+    ///     setResponse = await client.DictionarySetFieldAsync(cacheName, "my dictionary", "counter", "0123ABC");
+    ///     if (setResponse is CacheDictionarySetFieldResponse.Error) { /* handle error */ }
+    ///
+    ///     var incrementResponse = await client.DictionaryIncrementAsync(cacheName, "my dictionary", "counter", amount: 42);
+    ///     if (incrementResponse is CacheDictionaryIncrementResponse.Error badIncrement)
+    ///     {
+    ///         Console.WriteLine($"Could not increment dictionary field: {badIncrement.Message}");
+    ///     }
+    /// </code>
+    /// </example>
+    public Task<CacheDictionaryIncrementResponse> DictionaryIncrementAsync(string cacheName, string dictionaryName, string field, long amount = 1, CollectionTtl ttl = default(CollectionTtl));
+
+    /// <summary>
+    /// Get several values from a dictionary.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="dictionaryName">The dictionary to lookup.</param>
+    /// <param name="fields">The fields in the dictionary to lookup.</param>
+    /// <returns>Task representing the status and associated value for each field.</returns>
+    public Task<CacheDictionaryGetFieldsResponse> DictionaryGetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields);
+
+    /// <inheritdoc cref="DictionaryGetFieldsAsync(string, string, IEnumerable{byte[]})"/>
+    public Task<CacheDictionaryGetFieldsResponse> DictionaryGetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<string> fields);
+
+    /// <summary>
+    /// Fetch the entire dictionary from the cache.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="dictionaryName">The dictionary to fetch.</param>
+    /// <returns>Task representing with the status of the fetch operation and the associated dictionary.</returns>
+    public Task<CacheDictionaryFetchResponse> DictionaryFetchAsync(string cacheName, string dictionaryName);
+
+    /// <summary>
+    /// Remove the dictionary from the cache.
+    ///
+    /// Performs a no-op if <paramref name="dictionaryName"/> does not exist.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to delete the dictionary from.</param>
+    /// <param name="dictionaryName">Name of the dictionary to delete.</param>
+    /// <returns>Task representing the result of the delete operation.</returns>
+    public Task<CacheDictionaryDeleteResponse> DictionaryDeleteAsync(string cacheName, string dictionaryName);
+
+    /// <summary>
+    /// Remove a field from a dictionary.
+    ///
+    /// Performs a no-op if <paramref name="dictionaryName"/> or <paramref name="field"/> does not exist.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to lookup the dictionary in.</param>
+    /// <param name="dictionaryName">Name of the dictionary to remove the field from.</param>
+    /// <param name="field">Name of the field to remove from the dictionary.</param>
+    /// <returns>Task representing the result of the cache operation.</returns>
+    public Task<CacheDictionaryRemoveFieldResponse> DictionaryRemoveFieldAsync(string cacheName, string dictionaryName, byte[] field);
+
+    /// <inheritdoc cref="DictionaryRemoveFieldAsync(string, string, byte[])"/>
+    public Task<CacheDictionaryRemoveFieldResponse> DictionaryRemoveFieldAsync(string cacheName, string dictionaryName, string field);
+
+    /// <summary>
+    /// Remove fields from a dictionary.
+    ///
+    /// Performs a no-op if <paramref name="dictionaryName"/> or a particular field does not exist.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to lookup the dictionary in.</param>
+    /// <param name="dictionaryName">Name of the dictionary to remove the field from.</param>
+    /// <param name="fields">Name of the fields to remove from the dictionary.</param>
+    /// <returns>Task representing the result of the cache operation.</returns>
+    public Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields);
+
+    /// <inheritdoc cref="DictionaryRemoveFieldsAsync(string, string, IEnumerable{byte[]})"/>
+    public Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, IEnumerable<string> fields);
+
+    /// <summary>
+    /// Add an element to a set in the cache.
+    ///
+    /// After this operation, the set will contain the union
+    /// of the element passed in and the elements of the set.
+    /// </summary>
+    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
+    /// <param name="cacheName">Name of the cache to store the set in.</param>
+    /// <param name="setName">The set to add the element to.</param>
+    /// <param name="element">The data to add to the set.</param>
+    /// <param name="ttl">TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <returns>Task representing the result of the cache operation.</returns>
+    public Task<CacheSetAddElementResponse> SetAddElementAsync(string cacheName, string setName, byte[] element, CollectionTtl ttl = default(CollectionTtl));
+
+    /// <inheritdoc cref="SetAddElementAsync(string, string, byte[], CollectionTtl)"/>
+    public Task<CacheSetAddElementResponse> SetAddElementAsync(string cacheName, string setName, string element, CollectionTtl ttl = default(CollectionTtl));
+
+    /// <summary>
+    /// Add several elements to a set in the cache.
+    ///
+    /// After this operation, the set will contain the union
+    /// of the elements passed in and the elements of the set.
+    /// </summary>
+    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
+    /// <param name="cacheName">Name of the cache to store the set in.</param>
+    /// <param name="setName">The set to add elements to.</param>
+    /// <param name="elements">The data to add to the set.</param>
+    /// <param name="ttl">TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <returns>Task representing the result of the cache operation.</returns>
+    public Task<CacheSetAddElementsResponse> SetAddElementsAsync(string cacheName, string setName, IEnumerable<byte[]> elements, CollectionTtl ttl = default(CollectionTtl));
+
+    /// <inheritdoc cref="SetAddElementsAsync(string, string, IEnumerable{byte[]}, CollectionTtl)"/>
+    public Task<CacheSetAddElementsResponse> SetAddElementsAsync(string cacheName, string setName, IEnumerable<string> elements, CollectionTtl ttl = default(CollectionTtl));
+
+    /// <summary>
+    /// Remove an element from a set.
+    ///
+    /// Performs a no-op if <paramref name="setName"/> or <paramref name="element"/> does not exist.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to lookup the set in.</param>
+    /// <param name="setName">The set to remove the element from.</param>
+    /// <param name="element">The data to remove from the set.</param>
+    /// <returns>Task representing the result of the cache operation.</returns>
+    public Task<CacheSetRemoveElementResponse> SetRemoveElementAsync(string cacheName, string setName, byte[] element);
+
+    /// <inheritdoc cref="SetRemoveElementAsync(string, string, byte[])"/>
+    public Task<CacheSetRemoveElementResponse> SetRemoveElementAsync(string cacheName, string setName, string element);
+
+    /// <summary>
+    /// Remove elements from a set.
+    ///
+    /// Performs a no-op if <paramref name="setName"/> or any of <paramref name="elements"/> do not exist.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to lookup the set in.</param>
+    /// <param name="setName">The set to remove the elements from.</param>
+    /// <param name="elements">The data to remove from the set.</param>
+    /// <returns>Task representing the result of the cache operation.</returns>
+    public Task<CacheSetRemoveElementsResponse> SetRemoveElementsAsync(string cacheName, string setName, IEnumerable<byte[]> elements);
+
+    /// <inheritdoc cref="SetRemoveElementsAsync(string, string, IEnumerable{byte[]})"/>
+    public Task<CacheSetRemoveElementsResponse> SetRemoveElementsAsync(string cacheName, string setName, IEnumerable<string> elements);
+
+    /// <summary>
+    /// Fetch the entire set from the cache.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="setName">The set to fetch.</param>
+    /// <returns>Task representing with the status of the fetch operation and the associated set.</returns>
+    public Task<CacheSetFetchResponse> SetFetchAsync(string cacheName, string setName);
+
+    /// <summary>
+    /// Remove the set from the cache.
+    ///
+    /// Performs a no-op if <paramref name="setName"/> does not exist.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to delete the set from.</param>
+    /// <param name="setName">Name of the set to delete.</param>
+    /// <returns>Task representing the result of the delete operation.</returns>
+    public Task<CacheSetDeleteResponse> SetDeleteAsync(string cacheName, string setName);
+
+    /// <summary>
+    /// Push a value to the beginning of a list.
+    /// </summary>
+    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
+    /// <param name="cacheName">Name of the cache to store the list in.</param>
+    /// <param name="listName">The list to push the value on.</param>
+    /// <param name="value">The value to push to the front of the list.</param>
+    /// <param name="ttl">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <param name="truncateBackToSize">Ensure the list does not exceed this length. Remove excess from the end of the list. Must be a positive number.</param>
+    /// <returns>Task representing the result of the push operation.</returns>
+    public Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, byte[] value, int? truncateBackToSize = null, CollectionTtl ttl = default(CollectionTtl));
+
+    /// <inheritdoc cref="ListPushFrontAsync(string, string, byte[], int?, CollectionTtl)"/>
+    public Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, string value, int? truncateBackToSize = null, CollectionTtl ttl = default(CollectionTtl));
+
+    /// <summary>
+    /// Push a value to the end of a list.
+    /// </summary>
+    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
+    /// <param name="cacheName">Name of the cache to store the list in.</param>
+    /// <param name="listName">The list to push the value on.</param>
+    /// <param name="value">The value to push to the back of the list.</param>
+    /// <param name="ttl">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <param name="truncateFrontToSize">Ensure the list does not exceed this length. Remove excess from the beginning of the list. Must be a positive number.</param>
+    /// <returns>Task representing the result of the push operation.</returns>
+    public Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, byte[] value, int? truncateFrontToSize = null, CollectionTtl ttl = default(CollectionTtl));
+
+    /// <inheritdoc cref="ListPushBackAsync(string, string, byte[], int?, CollectionTtl)"/>
+    public Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, string value, int? truncateFrontToSize = null, CollectionTtl ttl = default(CollectionTtl));
+
+    /// <summary>
+    /// Retrieve and remove the first item from a list.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to read the list from.</param>
+    /// <param name="listName">The list to pop from.</param>
+    /// <returns>Task representing the status and associated value for the pop operation.</returns>
+    public Task<CacheListPopFrontResponse> ListPopFrontAsync(string cacheName, string listName);
+
+    /// <summary>
+    /// Retrieve and remove the last item from a list.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to read the list from.</param>
+    /// <param name="listName">The list to pop from.</param>
+    /// <returns>Task representing the status and associated value for the pop operation.</returns>
+    public Task<CacheListPopBackResponse> ListPopBackAsync(string cacheName, string listName);
+
+    /// <summary>
+    /// Fetch the entire list from the cache.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="listName">The list to fetch.</param>
+    /// <returns>Task representing with the status of the fetch operation and the associated list.</returns>
+    public Task<CacheListFetchResponse> ListFetchAsync(string cacheName, string listName);
+
+    /// <summary>
+    /// Remove all elements in a list equal to a particular value.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="listName">The list to remove elements from.</param>
+    /// <param name="value">The value to completely remove from the list.</param>
+    /// <returns>Task representing the result of the cache operation.</returns>
+    public Task<CacheListRemoveValueResponse> ListRemoveValueAsync(string cacheName, string listName, byte[] value);
+
+    /// <inheritdoc cref="ListRemoveValueAsync(string, string, byte[])"/>
+    public Task<CacheListRemoveValueResponse> ListRemoveValueAsync(string cacheName, string listName, string value);
+
+    /// <summary>
+    /// Calculate the length of a list in the cache.
+    ///
+    /// A list that does not exist is interpreted to have length 0.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="listName">The list to calculate length.</param>
+    /// <returns>Task representing the length of the list.</returns>
+    public Task<CacheListLengthResponse> ListLengthAsync(string cacheName, string listName);
+
+    /// <summary>
+    /// Remove the list from the cache.
+    ///
+    /// Performs a no-op if <paramref name="listName"/> does not exist.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to delete the list from.</param>
+    /// <param name="listName">Name of the list to delete.</param>
+    /// <returns>Task representing the result of the delete operation.</returns>
+    public Task<CacheListDeleteResponse> ListDeleteAsync(string cacheName, string listName);
+}

--- a/src/Momento.Sdk.Incubating/SimpleCacheClient.cs
+++ b/src/Momento.Sdk.Incubating/SimpleCacheClient.cs
@@ -19,9 +19,9 @@ namespace Momento.Sdk.Incubating;
 ///
 /// This enables preview features not ready for general release.
 /// </summary>
-public class SimpleCacheClient : ISimpleCacheClient
+public class SimpleCacheClient : Momento.Sdk.Incubating.ISimpleCacheClient
 {
-    private readonly ISimpleCacheClient simpleCacheClient;
+    private readonly Momento.Sdk.ISimpleCacheClient simpleCacheClient;
     private readonly ScsDataClient dataClient;
     protected readonly IConfiguration config;
     protected readonly ILogger _logger;
@@ -36,7 +36,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="authProvider">Momento JWT.</param>
     /// <param name="defaultTtl">Default time to live for the item in cache.</param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="defaultTtl"/> is zero or negative.</exception>
-    public SimpleCacheClient(ISimpleCacheClient simpleCacheClient, IConfiguration config, ICredentialProvider authProvider, TimeSpan defaultTtl)
+    public SimpleCacheClient(Momento.Sdk.ISimpleCacheClient simpleCacheClient, IConfiguration config, ICredentialProvider authProvider, TimeSpan defaultTtl)
     {
         this.simpleCacheClient = simpleCacheClient;
         this.config = config;
@@ -106,12 +106,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     }
 
 #if USE_UNARY_BATCH
-    /// <summary>
-    /// Gets multiple values from the cache.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-    /// <param name="keys">The keys to get.</param>
-    /// <returns>Task object representing the statuses of the get operation and the associated values.</returns>
+    /// <inheritdoc />
     public async Task<CacheGetBatchResponse> GetBatchAsync(string cacheName, IEnumerable<byte[]> keys)
     {
         try
@@ -127,7 +122,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.GetBatchAsync(this, cacheName, keys);
     }
 
-    /// <inheritdoc cref="GetBatchAsync(string, IEnumerable{byte[]})"/>
+    /// <inheritdoc />
     public async Task<CacheGetBatchResponse> GetBatchAsync(string cacheName, IEnumerable<string> keys)
     {
         try
@@ -143,13 +138,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.GetBatchAsync(this, cacheName, keys);
     }
 
-    /// <summary>
-    /// Sets multiple items in the cache. Overwrites existing items.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to store the items in.</param>
-    /// <param name="items">The items to set.</param>
-    /// <param name="ttl">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <returns>Task object representing the result of the set operation.</returns>
+    /// <inheritdoc />
     public async Task<CacheSetBatchResponse> SetBatchAsync(string cacheName, IEnumerable<KeyValuePair<byte[], byte[]>> items, TimeSpan? ttl = null)
     {
         try
@@ -165,7 +154,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetBatchAsync(this, cacheName, items, ttl);
     }
 
-    /// <inheritdoc cref="SetBatchAsync(string, IEnumerable{KeyValuePair{byte[], byte[]}}, TimeSpan?)"/>
+    /// <inheritdoc />
     public async Task<CacheSetBatchResponse> SetBatchAsync(string cacheName, IEnumerable<KeyValuePair<string, string>> items, TimeSpan? ttl = null)
     {
         try
@@ -181,19 +170,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetBatchAsync(this, cacheName, items, ttl);
     }
 #endif
-
-    /// <summary>
-    /// Set the dictionary field to a value with a given time to live (TTL) seconds.
-    /// </summary>
-    /// <remark>
-    /// Creates the data structure if it does not exist
-    /// </remark>
-    /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
-    /// <param name="dictionaryName">The dictionary to set.</param>
-    /// <param name="field">The field in the dictionary to set.</param>
-    /// <param name="value">The value to be stored.</param>
-    /// <param name="ttl">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
+    /// <inheritdoc />
     public async Task<CacheDictionarySetFieldResponse> DictionarySetFieldAsync(string cacheName, string dictionaryName, byte[] field, byte[] value, CollectionTtl ttl = default(CollectionTtl))
     {
         try
@@ -211,7 +188,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl);
     }
 
-    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)"/>
+    /// <inheritdoc />
     public async Task<CacheDictionarySetFieldResponse> DictionarySetFieldAsync(string cacheName, string dictionaryName, string field, string value, CollectionTtl ttl = default(CollectionTtl))
     {
         try
@@ -229,7 +206,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl);
     }
 
-    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)"/>
+    /// <inheritdoc />
     public async Task<CacheDictionarySetFieldResponse> DictionarySetFieldAsync(string cacheName, string dictionaryName, string field, byte[] value, CollectionTtl ttl = default(CollectionTtl))
     {
         try
@@ -247,13 +224,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl);
     }
 
-    /// <summary>
-    /// Get the cache value stored for the given dictionary and field.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-    /// <param name="dictionaryName">The dictionary to lookup.</param>
-    /// <param name="field">The field in the dictionary to lookup.</param>
-    /// <returns>Task representing the status of the get operation and the associated value.</returns>
+    /// <inheritdoc />
     public async Task<CacheDictionaryGetFieldResponse> DictionaryGetFieldAsync(string cacheName, string dictionaryName, byte[] field)
     {
         try
@@ -270,7 +241,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
     }
 
-    /// <inheritdoc cref="DictionaryGetFieldAsync(string, string, byte[])"/>
+    /// <inheritdoc />
     public async Task<CacheDictionaryGetFieldResponse> DictionaryGetFieldAsync(string cacheName, string dictionaryName, string field)
     {
         try
@@ -287,15 +258,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
     }
 
-    /// <summary>
-    /// Set several dictionary field-value pairs in the cache.
-    /// </summary>
-    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
-    /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
-    /// <param name="dictionaryName">The dictionary to set.</param>
-    /// <param name="items">The field-value pairs in the dictionary to set.</param>
-    /// <param name="ttl">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
+    /// <inheritdoc />
     public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
     {
         try
@@ -313,7 +276,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionarySetFieldsAsync(cacheName, dictionaryName, items, ttl);
     }
 
-    /// <inheritdoc cref="DictionarySetFieldsAsync(string, string, IEnumerable{KeyValuePair{byte[], byte[]}}, CollectionTtl)"/>
+    /// <inheritdoc />
     public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, string>> items, CollectionTtl ttl = default(CollectionTtl))
     {
         try
@@ -331,7 +294,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionarySetFieldsAsync(cacheName, dictionaryName, items, ttl);
     }
 
-    /// <inheritdoc cref="DictionarySetFieldsAsync(string, string, IEnumerable{KeyValuePair{byte[], byte[]}}, CollectionTtl)"/>
+    /// <inheritdoc />
     public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
     {
         try
@@ -349,56 +312,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionarySetFieldsAsync(cacheName, dictionaryName, items, ttl);
     }
 
-    /// <summary>
-    /// <para>Add an integer quantity to a dictionary value.</para>
-    ///
-    /// <para>Incrementing the value of a missing field sets the value to <paramref name="amount"/>.</para>
-    /// <para>Incrementing a value that was not set using this method or not the string representation of an integer
-    /// results in an error with <see cref="FailedPreconditionException"/>.</para>
-    /// </summary>
-    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
-    /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
-    /// <param name="dictionaryName">The dictionary to set.</param>
-    /// <param name="field"></param>
-    /// <param name="amount">The quantity to add to the value. May be positive, negative, or zero. Defaults to 1.</param>
-    /// <param name="ttl">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
-    /// <example>
-    /// The following illustrates a typical workflow:
-    /// <code>
-    ///     var response = await client.DictionaryIncrementAsync(cacheName, "my dictionary", "counter", amount: 42);
-    ///     if (response is CacheDictionaryIncrementResponse.Success success)
-    ///     {
-    ///         Console.WriteLine($"Current value is {success.Value}");
-    ///     }
-    ///     else if (response is CacheDictionaryIncrementResponse.Error error)
-    ///     {
-    ///         Console.WriteLine($"Got an error: {error.Message}");
-    ///     }
-    ///
-    ///     // Reset the counter. Note we use the string representation of an integer.
-    ///     var setResponse = await client.DictionarySetFieldAsync(cacheName, "my dictionary", "counter", "0");
-    ///     if (setResponse is CacheDictionarySetFieldResponse.Error) { /* handle error */ }
-    ///
-    ///     // Retrieve the counter. The integer is represented as a string.
-    ///     var getResponse = await client.DictionaryGetFieldAsync(cacheName, "my dictionary", "counter");
-    ///     if (getResponse is CacheDictionaryGetFieldResponse.Hit getHit)
-    ///     {
-    ///         Console.WriteLine(getHit.String());
-    ///     }
-    ///     else if (getResponse is CacheDictionaryGetFieldResponse.Error) { /* handle error */ }
-    ///
-    ///     // Here we try incrementing a value that isn't an integer. This results in an error with <see cref="FailedPreconditionException"/>
-    ///     setResponse = await client.DictionarySetFieldAsync(cacheName, "my dictionary", "counter", "0123ABC");
-    ///     if (setResponse is CacheDictionarySetFieldResponse.Error) { /* handle error */ }
-    ///
-    ///     var incrementResponse = await client.DictionaryIncrementAsync(cacheName, "my dictionary", "counter", amount: 42);
-    ///     if (incrementResponse is CacheDictionaryIncrementResponse.Error badIncrement)
-    ///     {
-    ///         Console.WriteLine($"Could not increment dictionary field: {badIncrement.Message}");
-    ///     }
-    /// </code>
-    /// </example>
+    /// <inheritdoc />
     public async Task<CacheDictionaryIncrementResponse> DictionaryIncrementAsync(string cacheName, string dictionaryName, string field, long amount = 1, CollectionTtl ttl = default(CollectionTtl))
     {
         try
@@ -415,13 +329,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionaryIncrementAsync(cacheName, dictionaryName, field, amount, ttl);
     }
 
-    /// <summary>
-    /// Get several values from a dictionary.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-    /// <param name="dictionaryName">The dictionary to lookup.</param>
-    /// <param name="fields">The fields in the dictionary to lookup.</param>
-    /// <returns>Task representing the status and associated value for each field.</returns>
+    /// <inheritdoc />
     public async Task<CacheDictionaryGetFieldsResponse> DictionaryGetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
     {
         try
@@ -438,7 +346,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionaryGetFieldsAsync(cacheName, dictionaryName, fields);
     }
 
-    /// <inheritdoc cref="DictionaryGetFieldsAsync(string, string, IEnumerable{byte[]})"/>
+    /// <inheritdoc />
     public async Task<CacheDictionaryGetFieldsResponse> DictionaryGetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<string> fields)
     {
         try
@@ -456,12 +364,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionaryGetFieldsAsync(cacheName, dictionaryName, fields);
     }
 
-    /// <summary>
-    /// Fetch the entire dictionary from the cache.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-    /// <param name="dictionaryName">The dictionary to fetch.</param>
-    /// <returns>Task representing with the status of the fetch operation and the associated dictionary.</returns>
+    /// <inheritdoc />
     public async Task<CacheDictionaryFetchResponse> DictionaryFetchAsync(string cacheName, string dictionaryName)
     {
         try
@@ -478,14 +381,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionaryFetchAsync(cacheName, dictionaryName);
     }
 
-    /// <summary>
-    /// Remove the dictionary from the cache.
-    ///
-    /// Performs a no-op if <paramref name="dictionaryName"/> does not exist.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to delete the dictionary from.</param>
-    /// <param name="dictionaryName">Name of the dictionary to delete.</param>
-    /// <returns>Task representing the result of the delete operation.</returns>
+    /// <inheritdoc />
     public async Task<CacheDictionaryDeleteResponse> DictionaryDeleteAsync(string cacheName, string dictionaryName)
     {
         try
@@ -502,15 +398,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionaryDeleteAsync(cacheName, dictionaryName);
     }
 
-    /// <summary>
-    /// Remove a field from a dictionary.
-    ///
-    /// Performs a no-op if <paramref name="dictionaryName"/> or <paramref name="field"/> does not exist.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to lookup the dictionary in.</param>
-    /// <param name="dictionaryName">Name of the dictionary to remove the field from.</param>
-    /// <param name="field">Name of the field to remove from the dictionary.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
+    /// <inheritdoc />
     public async Task<CacheDictionaryRemoveFieldResponse> DictionaryRemoveFieldAsync(string cacheName, string dictionaryName, byte[] field)
     {
         try
@@ -527,7 +415,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionaryRemoveFieldAsync(cacheName, dictionaryName, field);
     }
 
-    /// <inheritdoc cref="DictionaryRemoveFieldAsync(string, string, byte[])"/>
+    /// <inheritdoc />
     public async Task<CacheDictionaryRemoveFieldResponse> DictionaryRemoveFieldAsync(string cacheName, string dictionaryName, string field)
     {
         try
@@ -545,15 +433,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionaryRemoveFieldAsync(cacheName, dictionaryName, field);
     }
 
-    /// <summary>
-    /// Remove fields from a dictionary.
-    ///
-    /// Performs a no-op if <paramref name="dictionaryName"/> or a particular field does not exist.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to lookup the dictionary in.</param>
-    /// <param name="dictionaryName">Name of the dictionary to remove the field from.</param>
-    /// <param name="fields">Name of the fields to remove from the dictionary.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
+    /// <inheritdoc />
     public async Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
     {
         try
@@ -571,7 +451,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, fields);
     }
 
-    /// <inheritdoc cref="DictionaryRemoveFieldsAsync(string, string, IEnumerable{byte[]})"/>
+    /// <inheritdoc />
     public async Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, IEnumerable<string> fields)
     {
         try
@@ -590,18 +470,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, fields);
     }
 
-    /// <summary>
-    /// Add an element to a set in the cache.
-    ///
-    /// After this operation, the set will contain the union
-    /// of the element passed in and the elements of the set.
-    /// </summary>
-    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
-    /// <param name="cacheName">Name of the cache to store the set in.</param>
-    /// <param name="setName">The set to add the element to.</param>
-    /// <param name="element">The data to add to the set.</param>
-    /// <param name="ttl">TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
+    /// <inheritdoc />
     public async Task<CacheSetAddElementResponse> SetAddElementAsync(string cacheName, string setName, byte[] element, CollectionTtl ttl = default(CollectionTtl))
     {
         try
@@ -618,7 +487,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetAddElementAsync(cacheName, setName, element, ttl);
     }
 
-    /// <inheritdoc cref="SetAddElementAsync(string, string, byte[], CollectionTtl)"/>
+    /// <inheritdoc />
     public async Task<CacheSetAddElementResponse> SetAddElementAsync(string cacheName, string setName, string element, CollectionTtl ttl = default(CollectionTtl))
     {
         try
@@ -635,18 +504,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetAddElementAsync(cacheName, setName, element, ttl);
     }
 
-    /// <summary>
-    /// Add several elements to a set in the cache.
-    ///
-    /// After this operation, the set will contain the union
-    /// of the elements passed in and the elements of the set.
-    /// </summary>
-    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
-    /// <param name="cacheName">Name of the cache to store the set in.</param>
-    /// <param name="setName">The set to add elements to.</param>
-    /// <param name="elements">The data to add to the set.</param>
-    /// <param name="ttl">TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
+    /// <inheritdoc />
     public async Task<CacheSetAddElementsResponse> SetAddElementsAsync(string cacheName, string setName, IEnumerable<byte[]> elements, CollectionTtl ttl = default(CollectionTtl))
     {
         try
@@ -664,7 +522,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetAddElementsAsync(cacheName, setName, elements, ttl);
     }
 
-    /// <inheritdoc cref="SetAddElementsAsync(string, string, IEnumerable{byte[]}, CollectionTtl)"/>
+    /// <inheritdoc />
     public async Task<CacheSetAddElementsResponse> SetAddElementsAsync(string cacheName, string setName, IEnumerable<string> elements, CollectionTtl ttl = default(CollectionTtl))
     {
         try
@@ -683,15 +541,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetAddElementsAsync(cacheName, setName, elements, ttl);
     }
 
-    /// <summary>
-    /// Remove an element from a set.
-    ///
-    /// Performs a no-op if <paramref name="setName"/> or <paramref name="element"/> does not exist.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to lookup the set in.</param>
-    /// <param name="setName">The set to remove the element from.</param>
-    /// <param name="element">The data to remove from the set.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
+    /// <inheritdoc />
     public async Task<CacheSetRemoveElementResponse> SetRemoveElementAsync(string cacheName, string setName, byte[] element)
     {
         try
@@ -708,7 +558,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetRemoveElementAsync(cacheName, setName, element);
     }
 
-    /// <inheritdoc cref="SetRemoveElementAsync(string, string, byte[])"/>
+    /// <inheritdoc />
     public async Task<CacheSetRemoveElementResponse> SetRemoveElementAsync(string cacheName, string setName, string element)
     {
         try
@@ -726,15 +576,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetRemoveElementAsync(cacheName, setName, element);
     }
 
-    /// <summary>
-    /// Remove elements from a set.
-    ///
-    /// Performs a no-op if <paramref name="setName"/> or any of <paramref name="elements"/> do not exist.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to lookup the set in.</param>
-    /// <param name="setName">The set to remove the elements from.</param>
-    /// <param name="elements">The data to remove from the set.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
+    /// <inheritdoc />
     public async Task<CacheSetRemoveElementsResponse> SetRemoveElementsAsync(string cacheName, string setName, IEnumerable<byte[]> elements)
     {
         try
@@ -752,7 +594,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetRemoveElementsAsync(cacheName, setName, elements);
     }
 
-    /// <inheritdoc cref="SetRemoveElementsAsync(string, string, IEnumerable{byte[]})"/>
+    /// <inheritdoc />
     public async Task<CacheSetRemoveElementsResponse> SetRemoveElementsAsync(string cacheName, string setName, IEnumerable<string> elements)
     {
         try
@@ -770,12 +612,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetRemoveElementsAsync(cacheName, setName, elements);
     }
 
-    /// <summary>
-    /// Fetch the entire set from the cache.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-    /// <param name="setName">The set to fetch.</param>
-    /// <returns>Task representing with the status of the fetch operation and the associated set.</returns>
+    /// <inheritdoc />
     public async Task<CacheSetFetchResponse> SetFetchAsync(string cacheName, string setName)
     {
         try
@@ -791,14 +628,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetFetchAsync(cacheName, setName);
     }
 
-    /// <summary>
-    /// Remove the set from the cache.
-    ///
-    /// Performs a no-op if <paramref name="setName"/> does not exist.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to delete the set from.</param>
-    /// <param name="setName">Name of the set to delete.</param>
-    /// <returns>Task representing the result of the delete operation.</returns>
+    /// <inheritdoc />
     public async Task<CacheSetDeleteResponse> SetDeleteAsync(string cacheName, string setName)
     {
         try
@@ -814,16 +644,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetDeleteAsync(cacheName, setName);
     }
 
-    /// <summary>
-    /// Push a value to the beginning of a list.
-    /// </summary>
-    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
-    /// <param name="cacheName">Name of the cache to store the list in.</param>
-    /// <param name="listName">The list to push the value on.</param>
-    /// <param name="value">The value to push to the front of the list.</param>
-    /// <param name="ttl">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <param name="truncateBackToSize">Ensure the list does not exceed this length. Remove excess from the end of the list. Must be a positive number.</param>
-    /// <returns>Task representing the result of the push operation.</returns>
+    /// <inheritdoc />
     public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, byte[] value, int? truncateBackToSize = null, CollectionTtl ttl = default(CollectionTtl))
     {
         try
@@ -845,7 +666,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.ListPushFrontAsync(cacheName, listName, value, truncateBackToSize, ttl);
     }
 
-    /// <inheritdoc cref="ListPushFrontAsync(string, string, byte[], int?, CollectionTtl)"/>
+    /// <inheritdoc />
     public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, string value, int? truncateBackToSize = null, CollectionTtl ttl = default(CollectionTtl))
     {
         try
@@ -867,16 +688,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.ListPushFrontAsync(cacheName, listName, value, truncateBackToSize, ttl);
     }
 
-    /// <summary>
-    /// Push a value to the end of a list.
-    /// </summary>
-    /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
-    /// <param name="cacheName">Name of the cache to store the list in.</param>
-    /// <param name="listName">The list to push the value on.</param>
-    /// <param name="value">The value to push to the back of the list.</param>
-    /// <param name="ttl">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <param name="truncateFrontToSize">Ensure the list does not exceed this length. Remove excess from the beginning of the list. Must be a positive number.</param>
-    /// <returns>Task representing the result of the push operation.</returns>
+    /// <inheritdoc />
     public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, byte[] value, int? truncateFrontToSize = null, CollectionTtl ttl = default(CollectionTtl))
     {
         try
@@ -898,7 +710,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.ListPushBackAsync(cacheName, listName, value, truncateFrontToSize, ttl);
     }
 
-    /// <inheritdoc cref="ListPushBackAsync(string, string, byte[], int?, CollectionTtl)"/>
+    /// <inheritdoc />
     public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, string value, int? truncateFrontToSize = null, CollectionTtl ttl = default(CollectionTtl))
     {
         try
@@ -920,12 +732,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.ListPushBackAsync(cacheName, listName, value, truncateFrontToSize, ttl);
     }
 
-    /// <summary>
-    /// Retrieve and remove the first item from a list.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to read the list from.</param>
-    /// <param name="listName">The list to pop from.</param>
-    /// <returns>Task representing the status and associated value for the pop operation.</returns>
+    /// <inheritdoc />
     public async Task<CacheListPopFrontResponse> ListPopFrontAsync(string cacheName, string listName)
     {
         try
@@ -941,12 +748,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.ListPopFrontAsync(cacheName, listName);
     }
 
-    /// <summary>
-    /// Retrieve and remove the last item from a list.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to read the list from.</param>
-    /// <param name="listName">The list to pop from.</param>
-    /// <returns>Task representing the status and associated value for the pop operation.</returns>
+    /// <inheritdoc />
     public async Task<CacheListPopBackResponse> ListPopBackAsync(string cacheName, string listName)
     {
         try
@@ -962,12 +764,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.ListPopBackAsync(cacheName, listName);
     }
 
-    /// <summary>
-    /// Fetch the entire list from the cache.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-    /// <param name="listName">The list to fetch.</param>
-    /// <returns>Task representing with the status of the fetch operation and the associated list.</returns>
+    /// <inheritdoc />
     public async Task<CacheListFetchResponse> ListFetchAsync(string cacheName, string listName)
     {
         try
@@ -983,13 +780,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.ListFetchAsync(cacheName, listName);
     }
 
-    /// <summary>
-    /// Remove all elements in a list equal to a particular value.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-    /// <param name="listName">The list to remove elements from.</param>
-    /// <param name="value">The value to completely remove from the list.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
+    /// <inheritdoc />
     public async Task<CacheListRemoveValueResponse> ListRemoveValueAsync(string cacheName, string listName, byte[] value)
     {
         try
@@ -1007,7 +798,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.ListRemoveValueAsync(cacheName, listName, value);
     }
 
-    /// <inheritdoc cref="ListRemoveValueAsync(string, string, byte[])"/>
+    /// <inheritdoc />
     public async Task<CacheListRemoveValueResponse> ListRemoveValueAsync(string cacheName, string listName, string value)
     {
         try
@@ -1025,14 +816,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.ListRemoveValueAsync(cacheName, listName, value);
     }
 
-    /// <summary>
-    /// Calculate the length of a list in the cache.
-    ///
-    /// A list that does not exist is interpreted to have length 0.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-    /// <param name="listName">The list to calculate length.</param>
-    /// <returns>Task representing the length of the list.</returns>
+    /// <inheritdoc />
     public async Task<CacheListLengthResponse> ListLengthAsync(string cacheName, string listName)
     {
         try
@@ -1048,14 +832,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.ListLengthAsync(cacheName, listName);
     }
 
-    /// <summary>
-    /// Remove the list from the cache.
-    ///
-    /// Performs a no-op if <paramref name="listName"/> does not exist.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to delete the list from.</param>
-    /// <param name="listName">Name of the list to delete.</param>
-    /// <returns>Task representing the result of the delete operation.</returns>
+    /// <inheritdoc />
     public async Task<CacheListDeleteResponse> ListDeleteAsync(string cacheName, string listName)
     {
         try

--- a/src/Momento.Sdk.Incubating/SimpleCacheClientFactory.cs
+++ b/src/Momento.Sdk.Incubating/SimpleCacheClientFactory.cs
@@ -18,7 +18,7 @@ public class SimpleCacheClientFactory
     /// <param name="authProvider">Momento JWT.</param>
     /// <param name="defaultTtl">Default time to live for the item in cache.</param>
     /// <returns>An instance of the incubating Simple Cache Client.</returns>
-    public static SimpleCacheClient CreateClient(IConfiguration config, ICredentialProvider authProvider, TimeSpan defaultTtl)
+    public static ISimpleCacheClient CreateClient(IConfiguration config, ICredentialProvider authProvider, TimeSpan defaultTtl)
     {
         var simpleCacheClient = new Momento.Sdk.SimpleCacheClient(config, authProvider, defaultTtl);
         return new SimpleCacheClient(simpleCacheClient, config, authProvider, defaultTtl);

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/Fixtures.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/Fixtures.cs
@@ -10,7 +10,7 @@ namespace Momento.Sdk.Incubating.Tests;
 /// </summary>
 public class SimpleCacheClientFixture : IDisposable
 {
-    public SimpleCacheClient Client { get; private set; }
+    public ISimpleCacheClient Client { get; private set; }
     public ICredentialProvider AuthProvider { get; private set; }
     public string CacheName { get; private set; }
 

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/TestBase.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/TestBase.cs
@@ -4,7 +4,7 @@ namespace Momento.Sdk.Incubating.Tests;
 
 public class TestBase
 {
-    protected readonly SimpleCacheClient client;
+    protected readonly ISimpleCacheClient client;
     protected readonly string cacheName;
     protected readonly ICredentialProvider authProvider;
     protected readonly TimeSpan defaultTtl = SimpleCacheClientFixture.DefaultTtl;


### PR DESCRIPTION
This follows the patter set in the prod SDK. The cache client
implements an `ISimpleCacheClient` interface. We introduce an
incubating interface to parallel the prod SDK one. By doing this we
improve testability (eg by enabling DI).

Closes #49 
