### PR TITLE
chore: refactor ScsDataClient for consistency of `Send` functions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+TODO: add more info here.
+
+To run integration tests:
+
+```
+dotnet test tests/Integration/Momento.Sdk.Incubating.Tests
+```

--- a/src/Momento.Sdk.Incubating/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk.Incubating/Internal/ScsDataClient.cs
@@ -131,6 +131,31 @@ internal sealed class ScsDataClient : ScsDataClientBase
     private _DictionaryFieldValuePair[] ToSingletonFieldValuePair(string field, string value) => new _DictionaryFieldValuePair[] { new _DictionaryFieldValuePair() { Field = field.ToByteString(), Value = value.ToByteString() } };
     private _DictionaryFieldValuePair[] ToSingletonFieldValuePair(string field, byte[] value) => new _DictionaryFieldValuePair[] { new _DictionaryFieldValuePair() { Field = field.ToByteString(), Value = value.ToByteString() } };
 
+    public async Task<CacheDictionaryFetchResponse> DictionaryFetchAsync(string cacheName, string dictionaryName)
+    {
+        return await SendDictionaryFetchAsync(cacheName, dictionaryName);
+    }
+
+    public async Task<CacheDictionaryGetFieldResponse> DictionaryGetFieldAsync(string cacheName, string dictionaryName, byte[] field)
+    {
+        return await SendDictionaryGetFieldAsync(cacheName, dictionaryName, field.ToSingletonByteString());
+    }
+
+    public async Task<CacheDictionaryGetFieldResponse> DictionaryGetFieldAsync(string cacheName, string dictionaryName, string field)
+    {
+        return await SendDictionaryGetFieldAsync(cacheName, dictionaryName, field.ToSingletonByteString());
+    }
+
+    public async Task<CacheDictionaryGetFieldsResponse> DictionaryGetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
+    {
+        return await SendDictionaryGetFieldsAsync(cacheName, dictionaryName, fields.ToEnumerableByteString());
+    }
+
+    public async Task<CacheDictionaryGetFieldsResponse> DictionaryGetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<string> fields)
+    {
+        return await SendDictionaryGetFieldsAsync(cacheName, dictionaryName, fields.ToEnumerableByteString());
+    }
+
     public async Task<CacheDictionarySetFieldResponse> DictionarySetFieldAsync(string cacheName, string dictionaryName, byte[] field, byte[] value, CollectionTtl ttl = default(CollectionTtl))
     {
         return await SendDictionarySetFieldAsync(cacheName, dictionaryName, ToSingletonFieldValuePair(field, value), ttl);
@@ -146,15 +171,187 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return await SendDictionarySetFieldAsync(cacheName, dictionaryName, ToSingletonFieldValuePair(field, value), ttl);
     }
 
-    public async Task<CacheDictionaryGetFieldResponse> DictionaryGetFieldAsync(string cacheName, string dictionaryName, byte[] field)
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
     {
-        return await SendDictionaryGetFieldAsync(cacheName, dictionaryName, field.ToSingletonByteString());
+        var protoItems = items.Select(kv => new _DictionaryFieldValuePair() { Field = kv.Key.ToByteString(), Value = kv.Value.ToByteString() });
+        return await SendDictionarySetFieldsAsync(cacheName, dictionaryName, protoItems, ttl);
     }
 
-    public async Task<CacheDictionaryGetFieldResponse> DictionaryGetFieldAsync(string cacheName, string dictionaryName, string field)
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, string>> items, CollectionTtl ttl = default(CollectionTtl))
     {
-        return await SendDictionaryGetFieldAsync(cacheName, dictionaryName, field.ToSingletonByteString());
+        var protoItems = items.Select(kv => new _DictionaryFieldValuePair() { Field = kv.Key.ToByteString(), Value = kv.Value.ToByteString() });
+        return await SendDictionarySetFieldsAsync(cacheName, dictionaryName, protoItems, ttl);
     }
+
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
+    {
+        var protoItems = items.Select(kv => new _DictionaryFieldValuePair() { Field = kv.Key.ToByteString(), Value = kv.Value.ToByteString() });
+        return await SendDictionarySetFieldsAsync(cacheName, dictionaryName, protoItems, ttl);
+    }
+
+    public async Task<CacheDictionaryIncrementResponse> DictionaryIncrementAsync(string cacheName, string dictionaryName, string field, long amount = 1, CollectionTtl ttl = default(CollectionTtl))
+    {
+        return await SendDictionaryIncrementAsync(cacheName, dictionaryName, field, amount, ttl);
+    }
+
+    public async Task<CacheDictionaryDeleteResponse> DictionaryDeleteAsync(string cacheName, string dictionaryName)
+    {
+        return await SendDictionaryDeleteAsync(cacheName, dictionaryName);
+    }
+
+    public async Task<CacheDictionaryRemoveFieldResponse> DictionaryRemoveFieldAsync(string cacheName, string dictionaryName, byte[] field)
+    {
+        return await SendDictionaryRemoveFieldAsync(cacheName, dictionaryName, field.ToByteString());
+    }
+
+    public async Task<CacheDictionaryRemoveFieldResponse> DictionaryRemoveFieldAsync(string cacheName, string dictionaryName, string field)
+    {
+        return await SendDictionaryRemoveFieldAsync(cacheName, dictionaryName, field.ToByteString());
+    }
+
+    public async Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
+    {
+        return await SendDictionaryRemoveFieldsAsync(cacheName, dictionaryName, fields.ToEnumerableByteString());
+    }
+
+    public async Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, IEnumerable<string> fields)
+    {
+        return await SendDictionaryRemoveFieldsAsync(cacheName, dictionaryName, fields.ToEnumerableByteString());
+    }
+
+    public async Task<CacheSetAddElementResponse> SetAddElementAsync(string cacheName, string setName, byte[] element, CollectionTtl ttl = default(CollectionTtl))
+    {
+        return await SendSetAddElementAsync(cacheName, setName, element.ToSingletonByteString(), ttl);
+    }
+
+    public async Task<CacheSetAddElementResponse> SetAddElementAsync(string cacheName, string setName, string element, CollectionTtl ttl = default(CollectionTtl))
+    {
+        return await SendSetAddElementAsync(cacheName, setName, element.ToSingletonByteString(), ttl);
+    }
+
+    public async Task<CacheSetAddElementsResponse> SetAddElementsAsync(string cacheName, string setName, IEnumerable<byte[]> elements, CollectionTtl ttl = default(CollectionTtl))
+    {
+        return await SendSetAddElementsAsync(cacheName, setName, elements.ToEnumerableByteString(), ttl);
+    }
+
+    public async Task<CacheSetAddElementsResponse> SetAddElementsAsync(string cacheName, string setName, IEnumerable<string> elements, CollectionTtl ttl = default(CollectionTtl))
+    {
+        return await SendSetAddElementsAsync(cacheName, setName, elements.ToEnumerableByteString(), ttl);
+    }
+
+    public async Task<CacheSetRemoveElementResponse> SetRemoveElementAsync(string cacheName, string setName, byte[] element)
+    {
+        return await SendSetRemoveElementAsync(cacheName, setName, element.ToSingletonByteString());
+    }
+
+    public async Task<CacheSetRemoveElementResponse> SetRemoveElementAsync(string cacheName, string setName, string element)
+    {
+        return await SendSetRemoveElementAsync(cacheName, setName, element.ToSingletonByteString());
+    }
+
+    public async Task<CacheSetRemoveElementsResponse> SetRemoveElementsAsync(string cacheName, string setName, IEnumerable<byte[]> elements)
+    {
+        return await SendSetRemoveElementsAsync(cacheName, setName, elements.ToEnumerableByteString());
+    }
+
+    public async Task<CacheSetRemoveElementsResponse> SetRemoveElementsAsync(string cacheName, string setName, IEnumerable<string> elements)
+    {
+        return await SendSetRemoveElementsAsync(cacheName, setName, elements.ToEnumerableByteString());
+    }
+
+    public async Task<CacheSetFetchResponse> SetFetchAsync(string cacheName, string setName)
+    {
+        return await SendSetFetchAsync(cacheName, setName);
+    }
+
+    public async Task<CacheSetDeleteResponse> SetDeleteAsync(string cacheName, string setName)
+    {
+        return await SendSetDeleteAsync(cacheName, setName);
+    }
+
+    public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, byte[] value, int? truncateBackToSize = null, CollectionTtl ttl = default(CollectionTtl))
+    {
+        return await SendListPushFrontAsync(cacheName, listName, value.ToByteString(), truncateBackToSize, ttl);
+    }
+
+    public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, string value, int? truncateBackToSize = null, CollectionTtl ttl = default(CollectionTtl))
+    {
+        return await SendListPushFrontAsync(cacheName, listName, value.ToByteString(), truncateBackToSize, ttl);
+    }
+
+    public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, byte[] value, int? truncateFrontToSize = null, CollectionTtl ttl = default(CollectionTtl))
+    {
+        return await SendListPushBackAsync(cacheName, listName, value.ToByteString(), truncateFrontToSize, ttl);
+    }
+
+    public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, string value, int? truncateFrontToSize = null, CollectionTtl ttl = default(CollectionTtl))
+    {
+        return await SendListPushBackAsync(cacheName, listName, value.ToByteString(), truncateFrontToSize, ttl);
+    }
+
+    public async Task<CacheListPopFrontResponse> ListPopFrontAsync(string cacheName, string listName)
+    {
+        return await SendListPopFrontAsync(cacheName, listName);
+    }
+
+    public async Task<CacheListPopBackResponse> ListPopBackAsync(string cacheName, string listName)
+    {
+        return await SendListPopBackAsync(cacheName, listName);
+    }
+
+    public async Task<CacheListFetchResponse> ListFetchAsync(string cacheName, string listName)
+    {
+        return await SendListFetchAsync(cacheName, listName);
+    }
+
+    public async Task<CacheListRemoveValueResponse> ListRemoveValueAsync(string cacheName, string listName, byte[] value)
+    {
+        return await SendListRemoveValueAsync(cacheName, listName, value.ToByteString());
+    }
+
+    public async Task<CacheListRemoveValueResponse> ListRemoveValueAsync(string cacheName, string listName, string value)
+    {
+        return await SendListRemoveValueAsync(cacheName, listName, value.ToByteString());
+    }
+
+    public async Task<CacheListLengthResponse> ListLengthAsync(string cacheName, string listName)
+    {
+        return await SendListLengthAsync(cacheName, listName);
+    }
+    
+    public async Task<CacheListDeleteResponse> ListDeleteAsync(string cacheName, string listName)
+    {
+        return await SendListDeleteAsync(cacheName, listName);
+    }
+
+
+    /***************************************************************************
+     * Private "Send" methods"
+     **************************************************************************/
+
+    private async Task<CacheDictionaryFetchResponse> SendDictionaryFetchAsync(string cacheName, string dictionaryName)
+    {
+        _DictionaryFetchRequest request = new() { DictionaryName = dictionaryName.ToByteString() };
+        _DictionaryFetchResponse response;
+        var metadata = MetadataWithCache(cacheName);
+
+        try
+        {
+            response = await this.grpcManager.Client.DictionaryFetchAsync(request, new CallOptions(headers: metadata, deadline: CalculateDeadline()));
+        }
+        catch (Exception e)
+        {
+            return new CacheDictionaryFetchResponse.Error(_exceptionMapper.Convert(e, metadata));
+        }
+
+        if (response.DictionaryCase == _DictionaryFetchResponse.DictionaryOneofCase.Found)
+        {
+            return new CacheDictionaryFetchResponse.Hit(response);
+        }
+
+        return new CacheDictionaryFetchResponse.Miss();
+    }
+
 
     private async Task<CacheDictionaryGetFieldResponse> SendDictionaryGetFieldAsync(string cacheName, string dictionaryName, IEnumerable<ByteString> fields)
     {
@@ -191,105 +388,6 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheDictionaryGetFieldResponse.Hit(response);
     }
 
-    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
-    {
-        var protoItems = items.Select(kv => new _DictionaryFieldValuePair() { Field = kv.Key.ToByteString(), Value = kv.Value.ToByteString() });
-        return await SendDictionarySetFieldsAsync(cacheName, dictionaryName, protoItems, ttl);
-    }
-
-    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, string>> items, CollectionTtl ttl = default(CollectionTtl))
-    {
-        var protoItems = items.Select(kv => new _DictionaryFieldValuePair() { Field = kv.Key.ToByteString(), Value = kv.Value.ToByteString() });
-        return await SendDictionarySetFieldsAsync(cacheName, dictionaryName, protoItems, ttl);
-    }
-
-    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
-    {
-        var protoItems = items.Select(kv => new _DictionaryFieldValuePair() { Field = kv.Key.ToByteString(), Value = kv.Value.ToByteString() });
-        return await SendDictionarySetFieldsAsync(cacheName, dictionaryName, protoItems, ttl);
-    }
-
-    public async Task<CacheDictionarySetFieldResponse> SendDictionarySetFieldAsync(string cacheName, string dictionaryName, IEnumerable<_DictionaryFieldValuePair> items, CollectionTtl ttl = default(CollectionTtl))
-    {
-        _DictionarySetRequest request = new()
-        {
-            DictionaryName = dictionaryName.ToByteString(),
-            RefreshTtl = ttl.RefreshTtl,
-            TtlMilliseconds = TtlToMilliseconds(ttl.Ttl)
-        };
-        request.Items.Add(items);
-        var metadata = MetadataWithCache(cacheName);
-
-        try
-        {
-            await this.grpcManager.Client.DictionarySetAsync(request, new CallOptions(headers: metadata, deadline: CalculateDeadline()));
-        }
-        catch (Exception e)
-        {
-            return new CacheDictionarySetFieldResponse.Error(_exceptionMapper.Convert(e, metadata));
-        }
-
-        return new CacheDictionarySetFieldResponse.Success();
-    }
-
-    public async Task<CacheDictionarySetFieldsResponse> SendDictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<_DictionaryFieldValuePair> items, CollectionTtl ttl = default(CollectionTtl))
-    {
-        _DictionarySetRequest request = new()
-        {
-            DictionaryName = dictionaryName.ToByteString(),
-            RefreshTtl = ttl.RefreshTtl,
-            TtlMilliseconds = TtlToMilliseconds(ttl.Ttl)
-        };
-        request.Items.Add(items);
-        var metadata = MetadataWithCache(cacheName);
-
-        try
-        {
-            await this.grpcManager.Client.DictionarySetAsync(request, new CallOptions(headers: metadata, deadline: CalculateDeadline()));
-        }
-        catch (Exception e)
-        {
-            return new CacheDictionarySetFieldsResponse.Error(_exceptionMapper.Convert(e, metadata));
-        }
-
-        return new CacheDictionarySetFieldsResponse.Success();
-    }
-
-    public async Task<CacheDictionaryIncrementResponse> DictionaryIncrementAsync(string cacheName, string dictionaryName, string field, long amount = 1, CollectionTtl ttl = default(CollectionTtl))
-    {
-        _DictionaryIncrementRequest request = new()
-        {
-            DictionaryName = dictionaryName.ToByteString(),
-            Field = field.ToByteString(),
-            Amount = amount,
-            RefreshTtl = ttl.RefreshTtl,
-            TtlMilliseconds = TtlToMilliseconds(ttl.Ttl)
-        };
-        _DictionaryIncrementResponse response;
-        var metadata = MetadataWithCache(cacheName);
-
-        try
-        {
-            response = await this.grpcManager.Client.DictionaryIncrementAsync(request, new CallOptions(headers: metadata, deadline: CalculateDeadline()));
-        }
-        catch (Exception e)
-        {
-            return new CacheDictionaryIncrementResponse.Error(_exceptionMapper.Convert(e, metadata));
-        }
-
-        return new CacheDictionaryIncrementResponse.Success(response);
-    }
-
-    public async Task<CacheDictionaryGetFieldsResponse> DictionaryGetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
-    {
-        return await SendDictionaryGetFieldsAsync(cacheName, dictionaryName, fields.ToEnumerableByteString());
-    }
-
-    public async Task<CacheDictionaryGetFieldsResponse> DictionaryGetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<string> fields)
-    {
-        return await SendDictionaryGetFieldsAsync(cacheName, dictionaryName, fields.ToEnumerableByteString());
-    }
-
     private async Task<CacheDictionaryGetFieldsResponse> SendDictionaryGetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<ByteString> fields)
     {
         _DictionaryGetRequest request = new() { DictionaryName = dictionaryName.ToByteString() };
@@ -314,30 +412,79 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheDictionaryGetFieldsResponse.Miss();
     }
 
-    public async Task<CacheDictionaryFetchResponse> DictionaryFetchAsync(string cacheName, string dictionaryName)
+    private async Task<CacheDictionarySetFieldResponse> SendDictionarySetFieldAsync(string cacheName, string dictionaryName, IEnumerable<_DictionaryFieldValuePair> items, CollectionTtl ttl)
     {
-        _DictionaryFetchRequest request = new() { DictionaryName = dictionaryName.ToByteString() };
-        _DictionaryFetchResponse response;
+        _DictionarySetRequest request = new()
+        {
+            DictionaryName = dictionaryName.ToByteString(),
+            RefreshTtl = ttl.RefreshTtl,
+            TtlMilliseconds = TtlToMilliseconds(ttl.Ttl)
+        };
+        request.Items.Add(items);
         var metadata = MetadataWithCache(cacheName);
 
         try
         {
-            response = await this.grpcManager.Client.DictionaryFetchAsync(request, new CallOptions(headers: metadata, deadline: CalculateDeadline()));
+            await this.grpcManager.Client.DictionarySetAsync(request, new CallOptions(headers: metadata, deadline: CalculateDeadline()));
         }
         catch (Exception e)
         {
-            return new CacheDictionaryFetchResponse.Error(_exceptionMapper.Convert(e, metadata));
+            return new CacheDictionarySetFieldResponse.Error(_exceptionMapper.Convert(e, metadata));
         }
 
-        if (response.DictionaryCase == _DictionaryFetchResponse.DictionaryOneofCase.Found)
-        {
-            return new CacheDictionaryFetchResponse.Hit(response);
-        }
-
-        return new CacheDictionaryFetchResponse.Miss();
+        return new CacheDictionarySetFieldResponse.Success();
     }
 
-    public async Task<CacheDictionaryDeleteResponse> DictionaryDeleteAsync(string cacheName, string dictionaryName)
+    private async Task<CacheDictionarySetFieldsResponse> SendDictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<_DictionaryFieldValuePair> items, CollectionTtl ttl)
+    {
+        _DictionarySetRequest request = new()
+        {
+            DictionaryName = dictionaryName.ToByteString(),
+            RefreshTtl = ttl.RefreshTtl,
+            TtlMilliseconds = TtlToMilliseconds(ttl.Ttl)
+        };
+        request.Items.Add(items);
+        var metadata = MetadataWithCache(cacheName);
+
+        try
+        {
+            await this.grpcManager.Client.DictionarySetAsync(request, new CallOptions(headers: metadata, deadline: CalculateDeadline()));
+        }
+        catch (Exception e)
+        {
+            return new CacheDictionarySetFieldsResponse.Error(_exceptionMapper.Convert(e, metadata));
+        }
+
+        return new CacheDictionarySetFieldsResponse.Success();
+    }
+
+
+    private async Task<CacheDictionaryIncrementResponse> SendDictionaryIncrementAsync(string cacheName, string dictionaryName, string field, long amount, CollectionTtl ttl)
+    {
+        _DictionaryIncrementRequest request = new()
+        {
+            DictionaryName = dictionaryName.ToByteString(),
+            Field = field.ToByteString(),
+            Amount = amount,
+            RefreshTtl = ttl.RefreshTtl,
+            TtlMilliseconds = TtlToMilliseconds(ttl.Ttl)
+        };
+        _DictionaryIncrementResponse response;
+        var metadata = MetadataWithCache(cacheName);
+
+        try
+        {
+            response = await this.grpcManager.Client.DictionaryIncrementAsync(request, new CallOptions(headers: metadata, deadline: CalculateDeadline()));
+        }
+        catch (Exception e)
+        {
+            return new CacheDictionaryIncrementResponse.Error(_exceptionMapper.Convert(e, metadata));
+        }
+
+        return new CacheDictionaryIncrementResponse.Success(response);
+    }
+
+    private async Task<CacheDictionaryDeleteResponse> SendDictionaryDeleteAsync(string cacheName, string dictionaryName)
     {
         _DictionaryDeleteRequest request = new()
         {
@@ -358,17 +505,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheDictionaryDeleteResponse.Success();
     }
 
-    public async Task<CacheDictionaryRemoveFieldResponse> DictionaryRemoveFieldAsync(string cacheName, string dictionaryName, byte[] field)
-    {
-        return await DictionaryRemoveFieldAsync(cacheName, dictionaryName, field.ToByteString());
-    }
-
-    public async Task<CacheDictionaryRemoveFieldResponse> DictionaryRemoveFieldAsync(string cacheName, string dictionaryName, string field)
-    {
-        return await DictionaryRemoveFieldAsync(cacheName, dictionaryName, field.ToByteString());
-    }
-
-    public async Task<CacheDictionaryRemoveFieldResponse> DictionaryRemoveFieldAsync(string cacheName, string dictionaryName, ByteString field)
+    private async Task<CacheDictionaryRemoveFieldResponse> SendDictionaryRemoveFieldAsync(string cacheName, string dictionaryName, ByteString field)
     {
         _DictionaryDeleteRequest request = new()
         {
@@ -390,17 +527,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheDictionaryRemoveFieldResponse.Success();
     }
 
-    public async Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
-    {
-        return await DictionaryRemoveFieldsAsync(cacheName, dictionaryName, fields.ToEnumerableByteString());
-    }
-
-    public async Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, IEnumerable<string> fields)
-    {
-        return await DictionaryRemoveFieldsAsync(cacheName, dictionaryName, fields.ToEnumerableByteString());
-    }
-
-    public async Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, IEnumerable<ByteString> fields)
+    private async Task<CacheDictionaryRemoveFieldsResponse> SendDictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, IEnumerable<ByteString> fields)
     {
         _DictionaryDeleteRequest request = new()
         {
@@ -422,27 +549,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheDictionaryRemoveFieldsResponse.Success();
     }
 
-    public async Task<CacheSetAddElementResponse> SetAddElementAsync(string cacheName, string setName, byte[] element, CollectionTtl ttl = default(CollectionTtl))
-    {
-        return await SendSetAddElementAsync(cacheName, setName, element.ToSingletonByteString(), ttl);
-    }
-
-    public async Task<CacheSetAddElementResponse> SetAddElementAsync(string cacheName, string setName, string element, CollectionTtl ttl = default(CollectionTtl))
-    {
-        return await SendSetAddElementAsync(cacheName, setName, element.ToSingletonByteString(), ttl);
-    }
-
-    public async Task<CacheSetAddElementsResponse> SetAddElementsAsync(string cacheName, string setName, IEnumerable<byte[]> elements, CollectionTtl ttl = default(CollectionTtl))
-    {
-        return await SendSetAddElementsAsync(cacheName, setName, elements.ToEnumerableByteString(), ttl);
-    }
-
-    public async Task<CacheSetAddElementsResponse> SetAddElementsAsync(string cacheName, string setName, IEnumerable<string> elements, CollectionTtl ttl = default(CollectionTtl))
-    {
-        return await SendSetAddElementsAsync(cacheName, setName, elements.ToEnumerableByteString(), ttl);
-    }
-
-    public async Task<CacheSetAddElementResponse> SendSetAddElementAsync(string cacheName, string setName, IEnumerable<ByteString> elements, CollectionTtl ttl = default(CollectionTtl))
+    private async Task<CacheSetAddElementResponse> SendSetAddElementAsync(string cacheName, string setName, IEnumerable<ByteString> elements, CollectionTtl ttl)
     {
         _SetUnionRequest request = new()
         {
@@ -465,7 +572,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheSetAddElementResponse.Success();
     }
 
-    public async Task<CacheSetAddElementsResponse> SendSetAddElementsAsync(string cacheName, string setName, IEnumerable<ByteString> elements, CollectionTtl ttl = default(CollectionTtl))
+    private async Task<CacheSetAddElementsResponse> SendSetAddElementsAsync(string cacheName, string setName, IEnumerable<ByteString> elements, CollectionTtl ttl)
     {
         _SetUnionRequest request = new()
         {
@@ -488,27 +595,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheSetAddElementsResponse.Success();
     }
 
-    public async Task<CacheSetRemoveElementResponse> SetRemoveElementAsync(string cacheName, string setName, byte[] element)
-    {
-        return await SendSetRemoveElementAsync(cacheName, setName, element.ToSingletonByteString());
-    }
-
-    public async Task<CacheSetRemoveElementResponse> SetRemoveElementAsync(string cacheName, string setName, string element)
-    {
-        return await SendSetRemoveElementAsync(cacheName, setName, element.ToSingletonByteString());
-    }
-
-    public async Task<CacheSetRemoveElementsResponse> SetRemoveElementsAsync(string cacheName, string setName, IEnumerable<byte[]> elements)
-    {
-        return await SendSetRemoveElementsAsync(cacheName, setName, elements.ToEnumerableByteString());
-    }
-
-    public async Task<CacheSetRemoveElementsResponse> SetRemoveElementsAsync(string cacheName, string setName, IEnumerable<string> elements)
-    {
-        return await SendSetRemoveElementsAsync(cacheName, setName, elements.ToEnumerableByteString());
-    }
-
-    public async Task<CacheSetRemoveElementResponse> SendSetRemoveElementAsync(string cacheName, string setName, IEnumerable<ByteString> elements)
+    private async Task<CacheSetRemoveElementResponse> SendSetRemoveElementAsync(string cacheName, string setName, IEnumerable<ByteString> elements)
     {
         _SetDifferenceRequest request = new()
         {
@@ -530,7 +617,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheSetRemoveElementResponse.Success();
     }
 
-    public async Task<CacheSetRemoveElementsResponse> SendSetRemoveElementsAsync(string cacheName, string setName, IEnumerable<ByteString> elements)
+    private async Task<CacheSetRemoveElementsResponse> SendSetRemoveElementsAsync(string cacheName, string setName, IEnumerable<ByteString> elements)
     {
         _SetDifferenceRequest request = new()
         {
@@ -552,7 +639,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheSetRemoveElementsResponse.Success();
     }
 
-    public async Task<CacheSetFetchResponse> SetFetchAsync(string cacheName, string setName)
+    private async Task<CacheSetFetchResponse> SendSetFetchAsync(string cacheName, string setName)
     {
         _SetFetchRequest request = new() { SetName = setName.ToByteString() };
         _SetFetchResponse response;
@@ -574,7 +661,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheSetFetchResponse.Miss();
     }
 
-    public async Task<CacheSetDeleteResponse> SetDeleteAsync(string cacheName, string setName)
+    private async Task<CacheSetDeleteResponse> SendSetDeleteAsync(string cacheName, string setName)
     {
         _SetDifferenceRequest request = new()
         {
@@ -595,17 +682,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheSetDeleteResponse.Success();
     }
 
-    public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, byte[] value, int? truncateBackToSize = null, CollectionTtl ttl = default(CollectionTtl))
-    {
-        return await SendListPushFrontAsync(cacheName, listName, value.ToByteString(), truncateBackToSize, ttl);
-    }
-
-    public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, string value, int? truncateBackToSize = null, CollectionTtl ttl = default(CollectionTtl))
-    {
-        return await SendListPushFrontAsync(cacheName, listName, value.ToByteString(), truncateBackToSize, ttl);
-    }
-
-    public async Task<CacheListPushFrontResponse> SendListPushFrontAsync(string cacheName, string listName, ByteString value, int? truncateBackToSize = null, CollectionTtl ttl = default(CollectionTtl))
+    private async Task<CacheListPushFrontResponse> SendListPushFrontAsync(string cacheName, string listName, ByteString value, int? truncateBackToSize, CollectionTtl ttl)
     {
         _ListPushFrontRequest request = new()
         {
@@ -630,17 +707,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheListPushFrontResponse.Success(response);
     }
 
-    public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, byte[] value, int? truncateFrontToSize = null, CollectionTtl ttl = default(CollectionTtl))
-    {
-        return await SendListPushBackAsync(cacheName, listName, value.ToByteString(), truncateFrontToSize, ttl);
-    }
-
-    public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, string value, int? truncateFrontToSize = null, CollectionTtl ttl = default(CollectionTtl))
-    {
-        return await SendListPushBackAsync(cacheName, listName, value.ToByteString(), truncateFrontToSize, ttl);
-    }
-
-    public async Task<CacheListPushBackResponse> SendListPushBackAsync(string cacheName, string listName, ByteString value, int? truncateFrontToSize = null, CollectionTtl ttl = default(CollectionTtl))
+    private async Task<CacheListPushBackResponse> SendListPushBackAsync(string cacheName, string listName, ByteString value, int? truncateFrontToSize, CollectionTtl ttl)
     {
         _ListPushBackRequest request = new()
         {
@@ -665,7 +732,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheListPushBackResponse.Success(response);
     }
 
-    public async Task<CacheListPopFrontResponse> ListPopFrontAsync(string cacheName, string listName)
+    private async Task<CacheListPopFrontResponse> SendListPopFrontAsync(string cacheName, string listName)
     {
         _ListPopFrontRequest request = new() { ListName = listName.ToByteString() };
         _ListPopFrontResponse response;
@@ -688,7 +755,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheListPopFrontResponse.Hit(response);
     }
 
-    public async Task<CacheListPopBackResponse> ListPopBackAsync(string cacheName, string listName)
+    private async Task<CacheListPopBackResponse> SendListPopBackAsync(string cacheName, string listName)
     {
         _ListPopBackRequest request = new() { ListName = listName.ToByteString() };
         _ListPopBackResponse response;
@@ -711,7 +778,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheListPopBackResponse.Hit(response);
     }
 
-    public async Task<CacheListFetchResponse> ListFetchAsync(string cacheName, string listName)
+    private async Task<CacheListFetchResponse> SendListFetchAsync(string cacheName, string listName)
     {
         _ListFetchRequest request = new() { ListName = listName.ToByteString() };
         _ListFetchResponse response;
@@ -734,17 +801,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheListFetchResponse.Miss();
     }
 
-    public async Task<CacheListRemoveValueResponse> ListRemoveValueAsync(string cacheName, string listName, byte[] value)
-    {
-        return await ListRemoveValueAsync(cacheName, listName, value.ToByteString());
-    }
-
-    public async Task<CacheListRemoveValueResponse> ListRemoveValueAsync(string cacheName, string listName, string value)
-    {
-        return await ListRemoveValueAsync(cacheName, listName, value.ToByteString());
-    }
-
-    public async Task<CacheListRemoveValueResponse> ListRemoveValueAsync(string cacheName, string listName, ByteString value)
+    private async Task<CacheListRemoveValueResponse> SendListRemoveValueAsync(string cacheName, string listName, ByteString value)
     {
         _ListRemoveRequest request = new()
         {
@@ -765,7 +822,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheListRemoveValueResponse.Success();
     }
 
-    public async Task<CacheListLengthResponse> ListLengthAsync(string cacheName, string listName)
+    private async Task<CacheListLengthResponse> SendListLengthAsync(string cacheName, string listName)
     {
         _ListLengthRequest request = new()
         {
@@ -786,7 +843,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheListLengthResponse.Success(response);
     }
 
-    public async Task<CacheListDeleteResponse> ListDeleteAsync(string cacheName, string listName)
+    private async Task<CacheListDeleteResponse> SendListDeleteAsync(string cacheName, string listName)
     {
         _ListEraseRequest request = new()
         {

--- a/src/Momento.Sdk.Incubating/Momento.Sdk.Incubating.csproj
+++ b/src/Momento.Sdk.Incubating/Momento.Sdk.Incubating.csproj
@@ -34,7 +34,7 @@
 		<RepositoryUrl>https://github.com/momentohq/client-sdk-dotnet-incubating</RepositoryUrl>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Momento.Sdk" Version="1.0.1" />
+		<PackageReference Include="Momento.Sdk" Version="1.1.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/Fixtures.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/Fixtures.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
 
@@ -22,7 +23,18 @@ public class SimpleCacheClientFixture : IDisposable
         CacheName = Environment.GetEnvironmentVariable("TEST_CACHE_NAME") ??
             throw new NullReferenceException("TEST_CACHE_NAME environment variable must be set.");
         CacheName += "-incubating";
-        Client = SimpleCacheClientFactory.CreateClient(Configurations.Laptop.Latest(), AuthProvider, defaultTtl: DefaultTtl);
+        Client = SimpleCacheClientFactory.CreateClient(Configurations.Laptop.Latest().WithLoggerFactory(
+                LoggerFactory.Create(builder => {
+                    builder.AddSimpleConsole(options =>
+                    {
+                        options.IncludeScopes = true;
+                        options.SingleLine = true;
+                        options.TimestampFormat = "hh:mm:ss ";
+                    });
+                    builder.AddFilter("Grpc.Net.Client", LogLevel.Error);
+                    builder.SetMinimumLevel(LogLevel.Trace);
+                })),
+            AuthProvider, defaultTtl: DefaultTtl);
 
 
         try

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/Momento.Sdk.Incubating.Tests.csproj
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/Momento.Sdk.Incubating.Tests.csproj
@@ -21,10 +21,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Momento.Sdk.Incubating\Momento.Sdk.Incubating.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Remove="Microsoft.Extensions.Logging.Console" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This commit contains no functional changes, just re-organizes
the code in ScsDataClient to make it simpler to maintain in
the future.  Changes include:

* We had a lot of helper functions that were intended for internal
  use; some were prefixed with the name `Send` and some were not.
  These are now all prefixed with the name `Send`.
* Some of the `Send` methods were private and some were not.  They
  are now all private.
* Some of the `Send` methods accepted optional arguments, which was
  not necessary.  They no longer accept optional arguments.
* Some of the public methods delegated to `Send` methods, others did
  not.  They now all delegate to `Send` methods.
* The private `Send` methods are all now moved to the bottom of the
  file so that the code organization is more consistent.

This will make it easier to maintain this code in the future, especially
when we need to apply mechanical changes.  For example, in a subsequent
PR I will be adding logging statements to all of the `Send` methods.
This will be much easier and less error-prone now that all of the methods
that require it are in one place in the code.

Also bumps to the latest version of the upstream Momento SDK and configures
logging for integration tests, in preparation for the next PR, which will add
the log statements.
