### PR TITLE
chore: reduce test suite log level

### DIFF
--- a/tests/Integration/Momento.Sdk.Incubating.Tests/Fixtures.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/Fixtures.cs
@@ -32,7 +32,7 @@ public class SimpleCacheClientFixture : IDisposable
                         options.TimestampFormat = "hh:mm:ss ";
                     });
                     builder.AddFilter("Grpc.Net.Client", LogLevel.Error);
-                    builder.SetMinimumLevel(LogLevel.Trace);
+                    builder.SetMinimumLevel(LogLevel.Information);
                 })),
             AuthProvider, defaultTtl: DefaultTtl);
 


### PR DESCRIPTION
Previously the test runner log level was set to trace. In the a future
PR we will allow this to be set from the command line.
