### PR TITLE
feat: add list concatenate apis

### DIFF
--- a/src/Momento.Sdk.Incubating/ISimpleCacheClient.cs
+++ b/src/Momento.Sdk.Incubating/ISimpleCacheClient.cs
@@ -261,8 +261,8 @@ public interface ISimpleCacheClient : Momento.Sdk.ISimpleCacheClient
     /// Push multiple values to the beginning of a list.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the list in.</param>
-    /// <param name="listName">The list to push the value on.</param>
-    /// <param name="values">The values to push to the front of the list.</param>
+    /// <param name="listName">The list to concatenate the values on.</param>
+    /// <param name="values">The values to concatenate to the front of the list.</param>
     /// <param name="ttl">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <param name="truncateBackToSize">Ensure the list does not exceed this length. Remove excess from the end of the list. Must be a positive number.</param>
     /// <returns>Task representing the result of the push operation.</returns>
@@ -275,8 +275,8 @@ public interface ISimpleCacheClient : Momento.Sdk.ISimpleCacheClient
     /// Push multiple values to the back of a list.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the list in.</param>
-    /// <param name="listName">The list to push the value on.</param>
-    /// <param name="values">The values to push to the front of the list.</param>
+    /// <param name="listName">The list to concatenate the values on.</param>
+    /// <param name="values">The values to concatenate to the front of the list.</param>
     /// <param name="ttl">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <param name="truncateFrontToSize">Ensure the list does not exceed this length. Remove excess from the front of the list. Must be a positive number.</param>
     /// <returns>Task representing the result of the push operation.</returns>

--- a/src/Momento.Sdk.Incubating/ISimpleCacheClient.cs
+++ b/src/Momento.Sdk.Incubating/ISimpleCacheClient.cs
@@ -258,6 +258,34 @@ public interface ISimpleCacheClient : Momento.Sdk.ISimpleCacheClient
     public Task<CacheSetFetchResponse> SetFetchAsync(string cacheName, string setName);
 
     /// <summary>
+    /// Push multiple values to the beginning of a list.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to store the list in.</param>
+    /// <param name="listName">The list to push the value on.</param>
+    /// <param name="values">The values to push to the front of the list.</param>
+    /// <param name="ttl">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <param name="truncateBackToSize">Ensure the list does not exceed this length. Remove excess from the end of the list. Must be a positive number.</param>
+    /// <returns>Task representing the result of the push operation.</returns>
+    public Task<CacheListConcatenateFrontResponse> ListConcatenateFrontAsync(string cacheName, string listName, IEnumerable<byte[]> values, int? truncateBackToSize = null, CollectionTtl ttl = default(CollectionTtl));
+
+    /// <inheritdoc cref="ListConcatenateFrontAsync(string, string, IEnumerable{byte[]}, int?, CollectionTtl)"/>
+    public Task<CacheListConcatenateFrontResponse> ListConcatenateFrontAsync(string cacheName, string listName, IEnumerable<string> value, int? truncateBackToSize = null, CollectionTtl ttl = default(CollectionTtl));
+
+    /// <summary>
+    /// Push multiple values to the back of a list.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to store the list in.</param>
+    /// <param name="listName">The list to push the value on.</param>
+    /// <param name="values">The values to push to the front of the list.</param>
+    /// <param name="ttl">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <param name="truncateFrontToSize">Ensure the list does not exceed this length. Remove excess from the front of the list. Must be a positive number.</param>
+    /// <returns>Task representing the result of the push operation.</returns>
+    public Task<CacheListConcatenateBackResponse> ListConcatenateBackAsync(string cacheName, string listName, IEnumerable<byte[]> values, int? truncateFrontToSize = null, CollectionTtl ttl = default(CollectionTtl));
+
+    /// <inheritdoc cref="ListConcatenateBackAsync(string, string, IEnumerable{byte[]}, int?, CollectionTtl)"/>
+    public Task<CacheListConcatenateBackResponse> ListConcatenateBackAsync(string cacheName, string listName, IEnumerable<string> value, int? truncateFrontToSize = null, CollectionTtl ttl = default(CollectionTtl));
+
+    /// <summary>
     /// Push a value to the beginning of a list.
     /// </summary>
     /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>

--- a/src/Momento.Sdk.Incubating/Responses/CacheListConcatenateBackResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheListConcatenateBackResponse.cs
@@ -1,0 +1,49 @@
+using Momento.Protos.CacheClient;
+using Momento.Sdk.Exceptions;
+
+namespace Momento.Sdk.Incubating.Responses;
+
+/// <summary>
+/// The result of a <c>ListConcatenateBack</c> command
+/// </summary>
+///
+public abstract class CacheListConcatenateBackResponse
+{
+    public class Success : CacheListConcatenateBackResponse
+    {
+        public int ListLength { get; private set; }
+        public Success(_ListConcatenateBackResponse response)
+        {
+            ListLength = checked((int)response.ListLength);
+        }
+    }
+    public class Error : CacheListConcatenateBackResponse
+    {
+        private readonly SdkException _error;
+        public Error(SdkException error)
+        {
+            _error = error;
+        }
+
+        public SdkException Exception
+        {
+            get => _error;
+        }
+
+        public MomentoErrorCode ErrorCode
+        {
+            get => _error.ErrorCode;
+        }
+
+        public string Message
+        {
+            get => $"{_error.MessageWrapper}: {_error.Message}";
+        }
+
+        public override string ToString()
+        {
+            return base.ToString() + ": " + Message;
+        }
+    }
+
+}

--- a/src/Momento.Sdk.Incubating/Responses/CacheListConcatenateFrontResponse.cs
+++ b/src/Momento.Sdk.Incubating/Responses/CacheListConcatenateFrontResponse.cs
@@ -1,0 +1,49 @@
+using Momento.Protos.CacheClient;
+using Momento.Sdk.Exceptions;
+
+namespace Momento.Sdk.Incubating.Responses;
+
+/// <summary>
+/// The result of a <c>ListConcatenateFront</c> command
+/// </summary>
+///
+public abstract class CacheListConcatenateFrontResponse
+{
+    public class Success : CacheListConcatenateFrontResponse
+    {
+        public int ListLength { get; private set; }
+        public Success(_ListConcatenateFrontResponse response)
+        {
+            ListLength = checked((int)response.ListLength);
+        }
+    }
+    public class Error : CacheListConcatenateFrontResponse
+    {
+        private readonly SdkException _error;
+        public Error(SdkException error)
+        {
+            _error = error;
+        }
+
+        public SdkException Exception
+        {
+            get => _error;
+        }
+
+        public MomentoErrorCode ErrorCode
+        {
+            get => _error.ErrorCode;
+        }
+
+        public string Message
+        {
+            get => $"{_error.MessageWrapper}: {_error.Message}";
+        }
+
+        public override string ToString()
+        {
+            return base.ToString() + ": " + Message;
+        }
+    }
+
+}

--- a/src/Momento.Sdk.Incubating/SimpleCacheClient.cs
+++ b/src/Momento.Sdk.Incubating/SimpleCacheClient.cs
@@ -612,6 +612,99 @@ public class SimpleCacheClient : Momento.Sdk.Incubating.ISimpleCacheClient
     }
 
     /// <inheritdoc />
+    public async Task<CacheListConcatenateFrontResponse> ListConcatenateFrontAsync(string cacheName, string listName, IEnumerable<byte[]> values, int? truncateBackToSize = null, CollectionTtl ttl = default(CollectionTtl))
+    {
+        try
+        {
+            Utils.ArgumentNotNull(cacheName, nameof(cacheName));
+            Utils.ArgumentNotNull(listName, nameof(listName));
+            Utils.ArgumentNotNull(values, nameof(values));
+            Utils.ElementsNotNull(values, nameof(values));
+            Utils.ArgumentStrictlyPositive(truncateBackToSize, nameof(truncateBackToSize));
+        }
+        catch (ArgumentNullException e)
+        {
+            return new CacheListConcatenateFrontResponse.Error(new InvalidArgumentException(e.Message));
+        }
+        catch (ArgumentOutOfRangeException e)
+        {
+            return new CacheListConcatenateFrontResponse.Error(new InvalidArgumentException(e.Message));
+        }
+
+        return await this.dataClient.ListConcatenateFrontAsync(cacheName, listName, values, truncateBackToSize, ttl);
+    }
+
+
+    /// <inheritdoc />
+    public async Task<CacheListConcatenateFrontResponse> ListConcatenateFrontAsync(string cacheName, string listName, IEnumerable<string> values, int? truncateBackToSize = null, CollectionTtl ttl = default(CollectionTtl))
+    {
+        try
+        {
+            Utils.ArgumentNotNull(cacheName, nameof(cacheName));
+            Utils.ArgumentNotNull(listName, nameof(listName));
+            Utils.ArgumentNotNull(values, nameof(values));
+            Utils.ElementsNotNull(values, nameof(values));
+            Utils.ArgumentStrictlyPositive(truncateBackToSize, nameof(truncateBackToSize));
+        }
+        catch (ArgumentNullException e)
+        {
+            return new CacheListConcatenateFrontResponse.Error(new InvalidArgumentException(e.Message));
+        }
+        catch (ArgumentOutOfRangeException e)
+        {
+            return new CacheListConcatenateFrontResponse.Error(new InvalidArgumentException(e.Message));
+        }
+
+        return await this.dataClient.ListConcatenateFrontAsync(cacheName, listName, values, truncateBackToSize, ttl);
+    }
+
+    /// <inheritdoc />
+    public async Task<CacheListConcatenateBackResponse> ListConcatenateBackAsync(string cacheName, string listName, IEnumerable<byte[]> values, int? truncateFrontToSize = null, CollectionTtl ttl = default(CollectionTtl))
+    {
+        try
+        {
+            Utils.ArgumentNotNull(cacheName, nameof(cacheName));
+            Utils.ArgumentNotNull(listName, nameof(listName));
+            Utils.ArgumentNotNull(values, nameof(values));
+            Utils.ElementsNotNull(values, nameof(values));
+            Utils.ArgumentStrictlyPositive(truncateFrontToSize, nameof(truncateFrontToSize));
+        }
+        catch (ArgumentNullException e)
+        {
+            return new CacheListConcatenateBackResponse.Error(new InvalidArgumentException(e.Message));
+        }
+        catch (ArgumentOutOfRangeException e)
+        {
+            return new CacheListConcatenateBackResponse.Error(new InvalidArgumentException(e.Message));
+        }
+
+        return await this.dataClient.ListConcatenateBackAsync(cacheName, listName, values, truncateFrontToSize, ttl);
+    }
+
+    /// <inheritdoc />
+    public async Task<CacheListConcatenateBackResponse> ListConcatenateBackAsync(string cacheName, string listName, IEnumerable<string> values, int? truncateFrontToSize = null, CollectionTtl ttl = default(CollectionTtl))
+    {
+        try
+        {
+            Utils.ArgumentNotNull(cacheName, nameof(cacheName));
+            Utils.ArgumentNotNull(listName, nameof(listName));
+            Utils.ArgumentNotNull(values, nameof(values));
+            Utils.ElementsNotNull(values, nameof(values));
+            Utils.ArgumentStrictlyPositive(truncateFrontToSize, nameof(truncateFrontToSize));
+        }
+        catch (ArgumentNullException e)
+        {
+            return new CacheListConcatenateBackResponse.Error(new InvalidArgumentException(e.Message));
+        }
+        catch (ArgumentOutOfRangeException e)
+        {
+            return new CacheListConcatenateBackResponse.Error(new InvalidArgumentException(e.Message));
+        }
+
+        return await this.dataClient.ListConcatenateBackAsync(cacheName, listName, values, truncateFrontToSize, ttl);
+    }
+
+    /// <inheritdoc />
     public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, byte[] value, int? truncateBackToSize = null, CollectionTtl ttl = default(CollectionTtl))
     {
         try


### PR DESCRIPTION
Follow-up for https://github.com/momentohq/client-sdk-dotnet-incubating/pull/42, the previous PR fell too far
behind `main` so resolving merge conflicts was way too difficult to do cleanly.

Adds `ListConcatenateFront` and `ListConcatenateBack` APIs with the updated way we do things for our C# SDK.

Unit tests have been updated and are passing when running my test token against alpha
